### PR TITLE
perf: 漫画列表接口性能修复，解决 30s 超时

### DIFF
--- a/comic_backend/application/comic_app_service.py
+++ b/comic_backend/application/comic_app_service.py
@@ -173,8 +173,10 @@ class ComicAppService:
                     error_logger.error(f"回填漫画存储路径失败（列表）: {c.id}, {persisted_error}")
 
                 # 确保封面存在（对未落地封面的内容，必要时用第 1 张图片生成）
+                # 仅对封面缺失或默认封面的漫画触发修复，避免对已有有效封面的漫画做磁盘 I/O
                 try:
-                    self._ensure_cover(c)
+                    if self._is_missing_cover_path(c.cover_path):
+                        self._ensure_cover(c)
                 except Exception as e:
                     error_logger.error(f"确保漫画封面失败（列表）: {c.id}, {e}")
 

--- a/comic_backend/application/comic_app_service.py
+++ b/comic_backend/application/comic_app_service.py
@@ -165,21 +165,6 @@ class ComicAppService:
             
             comic_list = []
             for c in comics:
-                try:
-                    if (not str(getattr(c, "storage_path_relative", "") or "").strip()) or (not str(getattr(c, "storage_path_kind", "") or "").strip()):
-                        if self._refresh_comic_persisted_metadata(c, source="local"):
-                            self._comic_repo.save(c)
-                except Exception as persisted_error:
-                    error_logger.error(f"回填漫画存储路径失败（列表）: {c.id}, {persisted_error}")
-
-                # 确保封面存在（对未落地封面的内容，必要时用第 1 张图片生成）
-                # 仅对封面缺失或默认封面的漫画触发修复，避免对已有有效封面的漫画做磁盘 I/O
-                try:
-                    if self._is_missing_cover_path(c.cover_path):
-                        self._ensure_cover(c)
-                except Exception as e:
-                    error_logger.error(f"确保漫画封面失败（列表）: {c.id}, {e}")
-
                 comic_list.append(self._comic_to_summary_dict(c, tag_map))
             
             app_logger.info(f"获取漫画列表成功，共 {len(comic_list)} 个漫画")


### PR DESCRIPTION
## 问题
issue:漫画多了 每次列表刷新会非常卡 要等10几秒 #26
漫画库页面 `GET /api/v1/comic/list` 加载漫画时，接口耗时 30s+ 超时。

## 根因
`comic_app_service.py` → `get_comic_list()` 循环中调用了两个方法：

| 方法 | 引入提交 | 问题 |
|---|---|---|
| `_refresh_comic_persisted_metadata()` | e2ee0ce | 缺失路径时调用 `comic_repo.save()`，每次 save 触发完整 JSON 读→改→写→备份 |
| `_ensure_cover()` | 5bc212c | 封面缺失时调用 `os.walk()` 递归遍历漫画目录 |

`comic_repo.save()` 内部走 `JsonStorage.atomic_update()`，每次执行完整 JSON 文件 I/O + 备份，对大库是灾难性的。

## 修复
从 `get_comic_list()` 循环中移除上述两个修复逻辑，恢复为"取数据→排序→返回"。
列表接口仅负责展示，路径回填和封面修复应作为一次性操作在导入时或后台任务中完成。

## 改动
- `comic_backend/application/comic_app_service.py`：移除循环中的修复调用（-15 行）