### PR TITLE
全网搜索增强 - 多平台选择、漫画标签搜索、视频代理优化

### DIFF
--- a/comic_backend/api/v1/comic.py
+++ b/comic_backend/api/v1/comic.py
@@ -27,7 +27,7 @@ from core.constants import (
 from core.utils import normalize_total_page
 from protocol.compatibility import get_query_status_for_adapter_name
 from protocol.gateway import get_protocol_gateway
-from protocol.presentation import annotate_items
+from protocol.presentation import annotate_items, annotate_item
 from .runtime_guard import require_third_party
 from application.teledrive_app_service import (
     TeleDriveBridgeError,
@@ -725,7 +725,18 @@ def search_third_party_comics():
         supported_platforms = sorted(platform_lookup.keys())
         if platform == 'all':
             platforms_to_search = available_plugins
+            is_multi_platform = False
+        elif ',' in platform:
+            platform_names = [p.strip().upper() for p in platform.split(',') if p.strip()]
+            platforms_to_search = []
+            for pname in platform_names:
+                descriptor = platform_lookup.get(pname)
+                if descriptor is None:
+                    return error_response(400, f"不支持的漫画平台: {pname}，支持的平台: {supported_platforms}")
+                platforms_to_search.append(descriptor)
+            is_multi_platform = True
         else:
+            is_multi_platform = False
             descriptor = platform_lookup.get(str(platform or "").strip().upper())
             if descriptor is None:
                 return error_response(400, f"不支持的漫画平台: {platform}，支持的平台: {supported_platforms}")
@@ -743,7 +754,7 @@ def search_third_party_comics():
             credential_status = get_query_status_for_adapter_name(adapter_name)
             if not bool(credential_status.get("configured", False)):
                 platform_errors[plat] = str(credential_status.get("message") or f"{plat} 平台未配置查询凭据")
-                if platform != 'all':
+                if not is_multi_platform and platform != 'all':
                     return error_response(400, platform_errors[plat])
                 continue
 
@@ -783,12 +794,12 @@ def search_third_party_comics():
             except RuntimeError as e:
                 platform_errors[plat] = str(e)
                 error_logger.error(f"搜索平台 {plat} 失败: {e}")
-                if platform != 'all':
+                if not is_multi_platform and platform != 'all':
                     return error_response(400, platform_errors[plat])
             except Exception as e:
                 error_logger.error(f"搜索平台 {plat} 失败: {e}")
                 platform_errors[plat] = f"{plat} 平台搜索失败"
-                if platform != 'all':
+                if not is_multi_platform and platform != 'all':
                     return error_response(500, platform_errors[plat])
                 continue
         
@@ -807,6 +818,105 @@ def search_third_party_comics():
     except Exception as e:
         error_logger.error(f"第三方搜索失败: {e}")
         return error_response(500, "服务器内部错误")
+
+
+@comic_bp.route('/third-party/<platform>/health-status', methods=['GET'])
+@require_third_party(error_response)
+def comic_third_party_health_status(platform):
+    try:
+        from protocol.host_service import get_protocol_host_service
+        host_service = get_protocol_host_service()
+        payload = host_service.execute_comic_platform(platform, "health.query.status")
+        return success_response(dict(payload or {}))
+    except Exception as e:
+        error_logger.error(f"检查漫画平台配置状态失败 platform={platform}: {e}")
+        return error_response(500, "server error")
+
+
+@comic_bp.route('/third-party/<platform>/tags', methods=['GET'])
+@require_third_party(error_response)
+def comic_third_party_tags(platform):
+    try:
+        keyword = (request.args.get('keyword') or '').strip().lower()
+        category_filter = (request.args.get('category') or '').strip().lower()
+        from protocol.host_service import get_protocol_host_service
+        host_service = get_protocol_host_service()
+        payload = host_service.execute_comic_platform(
+            platform,
+            "taxonomy.tags",
+            params={
+                "keyword": keyword,
+                "category": category_filter,
+            },
+        )
+        return success_response(dict(payload or {}))
+    except Exception as e:
+        error_logger.error(f"获取漫画平台标签失败 platform={platform}: {e}")
+        return error_response(500, "server error")
+
+
+@comic_bp.route('/third-party/<platform>/search-by-tags', methods=['GET', 'POST'])
+@require_third_party(error_response)
+def comic_third_party_tag_search(platform):
+    try:
+        page = request.args.get('page', 1, type=int) or 1
+        page = max(page, 1)
+
+        requested_tag_ids = request.args.getlist('tag_ids')
+        if not requested_tag_ids:
+            csv_tag_ids = (request.args.get('tag_ids') or '').strip()
+            if csv_tag_ids:
+                requested_tag_ids = [part.strip() for part in csv_tag_ids.split(',') if part.strip()]
+
+        from protocol.host_service import get_protocol_host_service
+        host_service = get_protocol_host_service()
+        payload = host_service.execute_comic_platform(
+            platform,
+            "taxonomy.tag_search",
+            params={
+                "page": page,
+                "tag_ids": requested_tag_ids,
+            },
+        )
+
+        result = dict(payload or {})
+        works = result.get('albums') or result.get('videos') or result.get('works') or []
+        albums = []
+
+        for work in works:
+            album = dict(work or {})
+            album['platform'] = platform
+            albums.append(
+                annotate_item(
+                    album,
+                    platform_name=platform,
+                    media_type="comic",
+                    capability="taxonomy.tag_search",
+                )
+            )
+
+        return success_response({
+            "platform": platform,
+            "page": result.get('page', page),
+            "has_next": result.get('has_next', False),
+            "total_pages": result.get('total_pages'),
+            "albums": albums,
+            "videos": albums,  # 兼容前端 video 字段约定
+            "query": result.get('query'),
+            "requested_tag_ids": result.get('requested_tag_ids', requested_tag_ids),
+            "effective_tag_ids": result.get('effective_tag_ids', []),
+            "invalid_tag_ids": result.get('invalid_tag_ids', []),
+            "overridden_tag_ids": result.get('overridden_tag_ids', []),
+        })
+    except ValueError as e:
+        error_logger.error(f"漫画平台标签搜索失败(参数) platform={platform}: {e}")
+        return error_response(400, str(e))
+    except PermissionError as e:
+        error_logger.error(f"漫画平台标签搜索失败(鉴权) platform={platform}: {e}")
+        return error_response(403, str(e))
+    except Exception as e:
+        error_logger.error(f"漫画平台标签搜索失败 platform={platform}: {e}")
+        return error_response(500, "server error")
 
 
 @comic_bp.route('/filter', methods=['GET'])

--- a/comic_backend/api/v1/video.py
+++ b/comic_backend/api/v1/video.py
@@ -2,7 +2,7 @@
 视频 API 路由
 """
 
-from flask import Blueprint, request, jsonify, Response, make_response, send_file
+from flask import Blueprint, request, jsonify, Response, make_response, send_file, stream_with_context
 from application.video_app_service import VideoAppService
 from application.actor_app_service import ActorAppService
 from application.content_sorting import (
@@ -41,6 +41,8 @@ from domain.tag.entity import ContentType
 import os
 import threading
 import time
+import base64
+from typing import Any
 from urllib.parse import parse_qs, quote, urlencode, urlparse
 import mimetypes
 import re
@@ -110,8 +112,30 @@ def _get_video_proxy_client():
 
 
 def _build_play_sources(code: str):
-    client = _get_video_proxy_client()
-    return client.build_sources(code)
+    """Build play sources from all plugins that support playback.sources.build."""
+    if not is_third_party_enabled():
+        raise RuntimeError(
+            f"third-party integration is disabled in current runtime profile: {get_runtime_profile()}"
+        )
+
+    gateway = get_protocol_gateway()
+    manifests = list(gateway.list_manifests(media_type="video", capability="playback.sources.build"))
+    if not manifests:
+        # fallback: use the default proxy client's build_sources
+        client = _get_video_proxy_client()
+        return client.build_sources(code)
+
+    all_sources = []
+    for manifest in manifests:
+        try:
+            client = gateway.get_client(manifest.plugin_id, proxy_base_path='/api/v1/video')
+            sources = client.build_sources(code)
+            if sources:
+                all_sources.extend(sources)
+        except Exception as e:
+            error_logger.error(f"build_sources failed for plugin {manifest.plugin_id}: {e}")
+
+    return all_sources
 
 
 def _get_video_recommendation_document_repository() -> JsonDocumentRepository:
@@ -484,6 +508,70 @@ def _resolve_remote_video_sources(video_id: str, video: dict, *, remote_provider
             requested_provider_key=requested_provider,
         )
     )
+
+
+def _resolve_third_party_play_urls(
+    video_id: str,
+    platform: str,
+    playback_source: str,
+    remote_provider: str = "",
+) -> Response:
+    """通过第三方平台 provider 解析播放链接。
+
+    当本地数据库中没有该视频（例如直接从第三方搜索结果进入详情页）时，
+    通过 protocol gateway 调用第三方 provider 获取详情和播放源。
+    """
+    try:
+        adapter = get_video_adapter(platform)
+        detail = adapter.get_video_detail(video_id)
+
+        if not detail or detail.get("found") is False:
+            return error_response(404, "视频不存在或无法获取详情")
+
+        detail_video = detail
+        if isinstance(detail_video.get("videos"), list) and len(detail_video["videos"]) > 0:
+            detail_video = detail_video["videos"][0]
+
+        code = str(detail_video.get("code") or detail_video.get("video_id") or video_id or "").strip()
+        title = str(detail_video.get("title") or "").strip()
+
+        if not is_third_party_enabled():
+            return error_response(
+                503,
+                f"third-party integration is disabled in current runtime profile: {get_runtime_profile()}",
+            )
+
+        provider_groups = []
+        if code:
+            try:
+                provider_groups.extend(_build_online_provider_groups(code))
+            except Exception as e:
+                error_logger.error(
+                    "[third_party_play_urls] build sources failed: video_id=%s, code=%s, error=%s",
+                    video_id,
+                    code,
+                    e,
+                )
+
+        if not provider_groups:
+            return error_response(400, "远程播放源不可用")
+
+        return success_response(
+            _build_play_urls_payload(
+                video_id=video_id,
+                code=code,
+                title=title,
+                playback_source="remote",
+                provider_groups=provider_groups,
+                requested_provider_key=remote_provider,
+            )
+        )
+    except RuntimeError as e:
+        error_logger.error("[third_party_play_urls] config error: %s", e)
+        return error_response(400, str(e))
+    except Exception as e:
+        error_logger.error("[third_party_play_urls] error: %s", e)
+        return error_response(500, "服务器内部错误")
 
 
 @video_bp.route('/list', methods=['GET'])
@@ -2314,7 +2402,19 @@ def third_party_search():
         supported_platforms = sorted({item["canonical_platform"] for item in search_plugins})
         if normalized_platform == 'all':
             platforms_to_search = search_plugins
+            is_multi_platform = False
+        elif ',' in normalized_platform:
+            # 多平台逗号分隔，如 "hanime1,javbus"
+            platform_names = [p.strip() for p in normalized_platform.split(',') if p.strip()]
+            platforms_to_search = []
+            for pname in platform_names:
+                descriptor = search_lookup.get(pname)
+                if descriptor is None:
+                    return error_response(400, f"不支持的视频平台: {pname}，支持的平台: {supported_platforms}")
+                platforms_to_search.append(descriptor)
+            is_multi_platform = True
         else:
+            is_multi_platform = False
             descriptor = search_lookup.get(normalized_platform)
             if descriptor is None:
                 return error_response(400, f"不支持的视频平台: {platform}，支持的平台: {supported_platforms}")
@@ -2330,7 +2430,7 @@ def third_party_search():
             status = _get_video_platform_query_status(plat)
             if not bool(status.get("configured", False)):
                 platform_errors[plat] = str(status.get("message") or f"{plat} 平台未配置查询凭据")
-                if normalized_platform != "all":
+                if not is_multi_platform and normalized_platform != "all":
                     return error_response(400, platform_errors[plat])
                 continue
 
@@ -2377,12 +2477,12 @@ def third_party_search():
             except RuntimeError as e:
                 platform_errors[plat] = str(e)
                 error_logger.error(f"搜索平台 {plat} 失败: {e}")
-                if normalized_platform != "all":
+                if not is_multi_platform and normalized_platform != "all":
                     return error_response(400, platform_errors[plat])
             except Exception as e:
                 error_logger.error(f"搜索平台 {plat} 失败: {e}")
                 platform_errors[plat] = f"{plat} 平台搜索失败"
-                if normalized_platform != "all":
+                if not is_multi_platform and normalized_platform != "all":
                     return error_response(500, platform_errors[plat])
                 continue
         
@@ -2392,7 +2492,10 @@ def third_party_search():
         total_pages = max(total_pages_list) if total_pages_list else 1
         
         response_data = {
-            "platform": 'all' if normalized_platform == 'all' else normalized_platform,
+            "platform": (
+                'all' if normalized_platform == 'all'
+                else normalized_platform
+            ),
             "page": page,
             "has_next": has_more,
             "total_pages": total_pages,
@@ -2441,19 +2544,50 @@ def third_party_detail():
             return error_response(400, "缺少参数")
         
         adapter = get_video_adapter(platform)
-        detail = adapter.get_video_detail(video_id)
+        resolved_platform, raw_id, manifest = _resolve_video_lookup_context(
+            video_id=video_id,
+            platform_name=platform,
+        )
+        detail = adapter.get_video_detail(raw_id or video_id)
         
-        if detail:
+        if detail and detail.get('found') is not False:
+            # get_video_detail 可能返回 {"videos": [detail]} 结构
+            detail_video = detail
+            if isinstance(detail_video.get('videos'), list) and len(detail_video['videos']) > 0:
+                detail_video = detail_video['videos'][0]
+
+            content_id = str(detail_video.get('video_id') or detail_video.get('id') or video_id or "").strip()
+            cover_url = str(detail_video.get('cover_url') or "").strip()
+            if cover_url:
+                detail_video['cover_url'] = to_proxy_image_url(
+                    cover_url,
+                    asset_kind="cover",
+                    video_id=content_id,
+                    platform_name=platform,
+                    content_id=content_id,
+                )
+            thumbs = detail_video.get('thumbnail_images') or []
+            if thumbs:
+                detail_video['thumbnail_images'] = [
+                    to_proxy_image_url(
+                        str(t),
+                        asset_kind="image",
+                        video_id=content_id,
+                        platform_name=platform,
+                        content_id=content_id,
+                    )
+                    for t in thumbs if str(t).strip()
+                ]
             return success_response(
                 annotate_item(
-                    detail,
+                    detail_video,
                     platform_name=platform,
                     media_type="video",
                     capability="catalog.detail",
                 )
             )
         else:
-            return error_response(404, "视频不存在")
+            return error_response(404, "视频不存在或未找到")
     except RuntimeError as e:
         error_logger.error(f"获取第三方详情失败(配置): {e}")
         return error_response(400, str(e))
@@ -3491,8 +3625,17 @@ def get_video_play_urls(video_id):
     try:
         playback_source = _normalize_playback_source_arg(request.args.get("playback_source", ""))
         remote_provider = _normalize_remote_provider_arg(request.args.get("remote_provider", ""))
+        platform = str(request.args.get("platform") or "").strip()
         result = video_service.get_video_detail(video_id)
         if not result.success or not result.data:
+            # 如果本地找不到视频但有 platform 参数，尝试第三方渠道
+            if platform:
+                app_logger.info(
+                    "[play-urls] video not found locally, trying third-party platform=%s, video_id=%s",
+                    platform,
+                    video_id,
+                )
+                return _resolve_third_party_play_urls(video_id, platform, playback_source, remote_provider)
             return error_response(404, "视频不存在")
         
         video = result.data
@@ -3588,19 +3731,119 @@ def proxy_video_request(domain, path):
         return Response(f'Proxy error: {str(e)}', status=500)
 
 
+def _extract_target_url(body_url: str, query_string: str) -> str:
+    """从请求参数中提取目标 URL。"""
+    target_url = str(body_url or "").strip()
+    if not target_url and query_string:
+        parsed = parse_qs(query_string)
+        url_param = parsed.get("url", [])
+        if url_param:
+            encoded = url_param[0]
+            try:
+                target_url = base64.b64decode(encoded).decode("utf-8")
+            except Exception:
+                target_url = encoded
+    return target_url
+
+
+def _find_proxy_client_for_url(target_url: str) -> Any:
+    """Find the matching playback proxy client by URL pattern.
+
+    Iterates over all video plugins with playback.proxy.url capability
+    and selects the one whose resource_policy match_hosts matches the target URL.
+    Falls back to the first available proxy client.
+    """
+    if not target_url:
+        app_logger.info(f"[proxy_route] target_url is empty, using fallback")
+        return _get_video_proxy_client()
+
+    parsed = urlparse(target_url)
+    target_host = str(parsed.netloc or "").strip().lower()
+    if not target_host:
+        app_logger.info(f"[proxy_route] target_url=%s: no host found, using fallback", target_url[:80])
+        return _get_video_proxy_client()
+
+    gateway = get_protocol_gateway()
+    manifests = list(gateway.list_manifests(media_type="video", capability="playback.proxy.url"))
+    app_logger.info(
+        "[proxy_route] target_host=%s, manifests_with_proxy_url=%s",
+        target_host,
+        [m.plugin_id for m in manifests],
+    )
+
+    for manifest in manifests:
+        try:
+            rp = manifest.resource_policy
+            app_logger.info(
+                "[proxy_route] checking manifest=%s, resource_policy_keys=%s",
+                manifest.plugin_id,
+                list(rp.keys()) if isinstance(rp, dict) else type(rp).__name__,
+            )
+            if not isinstance(rp, dict):
+                continue
+            # resource_policy 结构: {"assets": {"image": {...}, "cover": {...}}}
+            assets = rp.get("assets", {})
+            if not isinstance(assets, dict):
+                app_logger.info("[proxy_route]   assets is not dict, type=%s", type(assets).__name__)
+                continue
+            for asset_key in ("image", "cover", "preview_video", "video", "asset"):
+                asset_policy = assets.get(asset_key, {})
+                if not isinstance(asset_policy, dict):
+                    continue
+                for raw_profile in (asset_policy.get("request_profiles") or []):
+                    if not isinstance(raw_profile, dict):
+                        continue
+                    match_hosts = [
+                        str(item or "").strip().lower()
+                        for item in (raw_profile.get("match_hosts") or [])
+                        if str(item or "").strip()
+                    ]
+                    if match_hosts and any(c in target_host for c in match_hosts):
+                        app_logger.info(
+                            "[proxy_route] => MATCHED: plugin=%s, match_hosts=%s, target_host=%s",
+                            manifest.plugin_id,
+                            match_hosts,
+                            target_host,
+                        )
+                        return gateway.get_client(
+                            manifest.plugin_id,
+                            proxy_base_path="/api/v1/video",
+                        )
+        except Exception as e:
+            error_logger.error(f"[proxy_route] EXCEPTION for {manifest.plugin_id}: {e}")
+            continue
+
+    fallback = _get_video_proxy_client()
+    app_logger.info(
+        "[proxy_route] => FALLBACK to %s (no match for host=%s)",
+        fallback.plugin_id if hasattr(fallback, 'plugin_id') else str(fallback),
+        target_host,
+    )
+    # fallback: use the first available proxy client
+    return _get_video_proxy_client()
+
+
 @video_bp.route('/proxy2', methods=['GET', 'POST', 'HEAD'])
 @require_third_party(error_response)
 def proxy_video_request2():
-    """代理视频请求（完整URL方式，支持重写m3u8）"""
+    """代理视频请求（完整URL方式，支持流式传输）。
+
+    关键优化：使用流式响应（chunked transfer），后端边下载边转发，
+    避免等待完整视频文件下载后才开始播放，大幅减少首帧时间。
+    """
     try:
         body_url = ''
         if request.method == 'POST':
             data = request.get_json(silent=True) or {}
             body_url = data.get('url', '')
 
-        proxy_result = _get_video_proxy_client().proxy_url(
+        query_string = request.query_string.decode()
+        target_url = _extract_target_url(body_url, query_string)
+        proxy_client = _find_proxy_client_for_url(target_url)
+
+        proxy_result = proxy_client.proxy_url(
             method=request.method,
-            query_string=request.query_string.decode(),
+            query_string=query_string,
             body_url=body_url,
             incoming_referer=request.headers.get('Referer', ''),
             incoming_headers={
@@ -3611,11 +3854,25 @@ def proxy_video_request2():
             }
         )
 
-        response = make_response(proxy_result.content)
-        response.status_code = proxy_result.status_code
-        for n, v in proxy_result.headers:
-            response.headers[n] = v
-        return response
+        # 流式传输：边下载边发送，浏览器可立即开始播放
+        def generate():
+            for chunk in proxy_result.iter_content(chunk_size=65536):
+                if chunk:
+                    yield chunk
+
+        resp_headers = {}
+        if hasattr(proxy_result.headers, "items"):
+            for n, v in proxy_result.headers.items():
+                resp_headers[n] = v
+        else:
+            for n, v in proxy_result.headers:
+                resp_headers[n] = v
+
+        return Response(
+            stream_with_context(generate()),
+            status=proxy_result.status_code,
+            headers=resp_headers,
+        )
     except ValueError as e:
         return Response(str(e), status=400)
     except Exception as e:

--- a/comic_backend/api/v1/video.py
+++ b/comic_backend/api/v1/video.py
@@ -112,26 +112,54 @@ def _get_video_proxy_client():
 
 
 def _build_play_sources(code: str):
-    """Build play sources from all plugins that support playback.sources.build."""
+    """Build play sources from all plugins that support playback.sources.build.
+
+    Always includes results from the default proxy client first (backward compat),
+    then appends results from any additional plugin manifests that declare
+    the playback.sources.build capability.
+    """
     if not is_third_party_enabled():
         raise RuntimeError(
             f"third-party integration is disabled in current runtime profile: {get_runtime_profile()}"
         )
 
+    all_sources = []
+    seen_keys = set()
+
+    # 1. Always try the default proxy client first (backward compat for tests & runtime)
+    try:
+        client = _get_video_proxy_client()
+        sources = client.build_sources(code)
+        for src in (sources or []):
+            key = _normalize_provider_key(
+                str(src.get("source") or src.get("platform") or src.get("name") or "").strip(),
+                "",
+            )
+            if key and key not in seen_keys:
+                seen_keys.add(key)
+                all_sources.append(src)
+            elif not key:
+                all_sources.append(src)
+    except Exception as e:
+        error_logger.error(f"build_sources from default proxy client failed: {e}")
+
+    # 2. Try plugin-based sources (additional, deduplicated by source key)
     gateway = get_protocol_gateway()
     manifests = list(gateway.list_manifests(media_type="video", capability="playback.sources.build"))
-    if not manifests:
-        # fallback: use the default proxy client's build_sources
-        client = _get_video_proxy_client()
-        return client.build_sources(code)
-
-    all_sources = []
     for manifest in manifests:
         try:
             client = gateway.get_client(manifest.plugin_id, proxy_base_path='/api/v1/video')
             sources = client.build_sources(code)
-            if sources:
-                all_sources.extend(sources)
+            for src in (sources or []):
+                key = _normalize_provider_key(
+                    str(src.get("source") or src.get("platform") or src.get("name") or "").strip(),
+                    "",
+                )
+                if key and key not in seen_keys:
+                    seen_keys.add(key)
+                    all_sources.append(src)
+                elif not key:
+                    all_sources.append(src)
         except Exception as e:
             error_logger.error(f"build_sources failed for plugin {manifest.plugin_id}: {e}")
 
@@ -3855,24 +3883,37 @@ def proxy_video_request2():
         )
 
         # 流式传输：边下载边发送，浏览器可立即开始播放
-        def generate():
-            for chunk in proxy_result.iter_content(chunk_size=65536):
-                if chunk:
-                    yield chunk
+        # 兼容非流式响应（如测试 mock 的 SimpleNamespace 不含 iter_content）
+        if hasattr(proxy_result, "iter_content"):
+            def generate():
+                for chunk in proxy_result.iter_content(chunk_size=65536):
+                    if chunk:
+                        yield chunk
 
-        resp_headers = {}
+            resp_headers = {}
+            if hasattr(proxy_result.headers, "items"):
+                for n, v in proxy_result.headers.items():
+                    resp_headers[n] = v
+            else:
+                for n, v in proxy_result.headers:
+                    resp_headers[n] = v
+
+            return Response(
+                stream_with_context(generate()),
+                status=proxy_result.status_code,
+                headers=resp_headers,
+            )
+
+        # fallback: 非流式响应（旧协议/测试 mock），使用 make_response
+        response = make_response(proxy_result.content)
+        response.status_code = proxy_result.status_code
         if hasattr(proxy_result.headers, "items"):
             for n, v in proxy_result.headers.items():
-                resp_headers[n] = v
+                response.headers[n] = v
         else:
             for n, v in proxy_result.headers:
-                resp_headers[n] = v
-
-        return Response(
-            stream_with_context(generate()),
-            status=proxy_result.status_code,
-            headers=resp_headers,
-        )
+                response.headers[n] = v
+        return response
     except ValueError as e:
         return Response(str(e), status=400)
     except Exception as e:

--- a/comic_backend/protocol/host_service.py
+++ b/comic_backend/protocol/host_service.py
@@ -335,7 +335,7 @@ class ProtocolHostService:
             raise ValueError(f"未知平台: {platform}")
         return self._gateway.get_client(manifest.plugin_id)
 
-    def execute_comic_platform(self, platform: Any, capability: str, params: Dict[str, Any]):
+    def execute_comic_platform(self, platform: Any, capability: str, params: Optional[Dict[str, Any]] = None):
         manifest = self._find_manifest(platform, media_type="comic", capability=capability)
         if manifest is None:
             raise ValueError(f"未知平台: {platform}")

--- a/comic_frontend/src/api/comic.js
+++ b/comic_frontend/src/api/comic.js
@@ -498,7 +498,26 @@ export const comicApi = {
    */
   batchDeletePermanently: (comicIds) => {
     return request.delete('/v1/comic/trash/batch-delete', { data: { comic_ids: comicIds } })
-  }
+  },
+
+  // ---------- 第三方平台标签搜索（漫画模式） ----------
+
+  thirdPartyPlatformHealthStatus(platform) {
+    return request.get(`/v1/comic/third-party/${platform}/health-status`)
+  },
+
+  thirdPartyPlatformTags(platform, keyword = '', category = '') {
+    return request.get(`/v1/comic/third-party/${platform}/tags`, {
+      params: { keyword, category }
+    })
+  },
+
+  thirdPartyPlatformSearchByTags(platform, tagIds = [], page = 1) {
+    const params = new URLSearchParams()
+    tagIds.forEach(tagId => params.append('tag_ids', tagId))
+    params.append('page', String(page))
+    return request.get(`/v1/comic/third-party/${platform}/search-by-tags?${params.toString()}`)
+  },
 }
 
 /**

--- a/comic_frontend/src/api/video.js
+++ b/comic_frontend/src/api/video.js
@@ -114,8 +114,8 @@ export const videoApi = {
     return request.get(`/v1/video/third-party/${normalizedPlatform}/search-by-tags?${params.toString()}`)
   },
   
-  thirdPartyDetail(videoId) {
-    return request.get('/v1/video/third-party/detail', { params: { video_id: videoId } })
+  thirdPartyDetail(videoId, params = {}) {
+    return request.get('/v1/video/third-party/detail', { params: { video_id: videoId, ...params } })
   },
   
   thirdPartyActorSearch(actorName) {

--- a/comic_frontend/src/stores/globalSearch.js
+++ b/comic_frontend/src/stores/globalSearch.js
@@ -1,0 +1,79 @@
+/**
+ * 全网搜索状态 Store
+ *
+ * 保持搜索结果在页面导航期间持久化。
+ * 仅在以下情况清空：
+ *  - 用户执行新的搜索（自动清空旧结果）
+ *  - 页面刷新或关闭（Pinia 默认行为）
+ */
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useGlobalSearchStore = defineStore('globalSearch', () => {
+  const keyword = ref('')
+  const results = ref([])
+  const hasMore = ref(false)
+  const currentPage = ref(0)
+  const selectedIds = ref([])
+  const paginationInfo = ref(null)
+  const searchExecuted = ref(false)
+  const videoMode = ref(false)
+  const selectedPlatforms = ref([])
+  const platformOptions = ref([])
+
+  function setSearchState({
+    keyword: kw,
+    results: res,
+    hasMore: hm,
+    currentPage: cp,
+    paginationInfo: pi,
+    videoMode: vm,
+  }) {
+    if (kw !== undefined) keyword.value = kw
+    if (res !== undefined) results.value = res
+    if (hm !== undefined) hasMore.value = hm
+    if (cp !== undefined) currentPage.value = cp
+    if (pi !== undefined) paginationInfo.value = pi
+    if (vm !== undefined) videoMode.value = vm
+  }
+
+  function clearResults() {
+    keyword.value = ''
+    results.value = []
+    hasMore.value = false
+    currentPage.value = 0
+    selectedIds.value = []
+    paginationInfo.value = null
+    searchExecuted.value = false
+  }
+
+  function clearSelection() {
+    selectedIds.value = []
+  }
+
+  function appendResults(newResults, newPage, newHasMore, newPaginationInfo) {
+    results.value = [...results.value, ...newResults]
+    currentPage.value = newPage
+    hasMore.value = newHasMore
+    if (newPaginationInfo) {
+      paginationInfo.value = newPaginationInfo
+    }
+  }
+
+  return {
+    keyword,
+    results,
+    hasMore,
+    currentPage,
+    selectedIds,
+    paginationInfo,
+    searchExecuted,
+    videoMode,
+    selectedPlatforms,
+    platformOptions,
+    setSearchState,
+    clearResults,
+    clearSelection,
+    appendResults,
+  }
+})

--- a/comic_frontend/src/stores/index.js
+++ b/comic_frontend/src/stores/index.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Store 统一导出
  * 集中管理所有 Pinia Store
  */
@@ -50,3 +50,6 @@ export { useRandomFeedStore } from './randomFeed'
 
 // 应用更新
 export { useAppUpdateStore } from './appUpdate'
+
+// 全网搜索
+export { useGlobalSearchStore } from './globalSearch'

--- a/comic_frontend/src/stores/video.js
+++ b/comic_frontend/src/stores/video.js
@@ -216,16 +216,28 @@ export const useVideoStore = defineStore('video', () => {
     }
   }
   
-  async function thirdPartySearch(keyword) {
+  async function thirdPartySearch(keyword, platform = 'all', page = 1, limit = 20) {
+    if (!keyword || keyword.trim() === '') {
+      return { results: [], platform_info: {}, page: 1, limit: 20, has_more: false }
+    }
     loading.value = true
     try {
-      const res = await videoApi.thirdPartySearch(keyword)
-      if (res.code === 200) {
-        return res.data || []
+      const res = await videoApi.thirdPartySearch(keyword, page, platform)
+      if (res.code === 200 && res.data) {
+        return {
+          results: Array.isArray(res.data.videos) ? res.data.videos : [],
+          platform: res.data.platform || 'all',
+          platform_info: res.data.platform_info || {},
+          page: res.data.page || 1,
+          total_pages: res.data.total_pages || 1,
+          has_more: Boolean(res.data.has_next),
+          total: res.data.total || 0,
+        }
       }
-      return []
+      return { results: [], platform: 'all', platform_info: {}, page: 1, limit: 20, has_more: false }
     } catch (e) {
-      return []
+      console.error('[Video] 第三方搜索失败:', e)
+      return { results: [], platform: 'all', platform_info: {}, page: 1, limit: 20, has_more: false }
     } finally {
       loading.value = false
     }

--- a/comic_frontend/src/views/VideoDetail.vue
+++ b/comic_frontend/src/views/VideoDetail.vue
@@ -235,6 +235,16 @@
           {{ localThumbnailImages.length > 0 ? '重新生成缩略图' : '生成缩略图' }}
         </van-button>
       </div>
+      <div v-else-if="isThirdParty && preferredThumbnailImages.length > 0" class="thumbnail-actions" style="margin-top: 12px;">
+        <van-button
+          type="default"
+          plain
+          size="small"
+          @click="showPreviewImages = !showPreviewImages"
+        >
+          {{ showPreviewImages ? '隐藏预览图' : `显示预览图（${preferredThumbnailImages.length} 张）` }}
+        </van-button>
+      </div>
     </div>
       
       <div v-if="video.magnets && video.magnets.length > 0" class="magnets-section">
@@ -635,6 +645,7 @@ const ASSET_REFRESH_DELAY_MS = 2500
 
 const videoId = computed(() => route.params.id)
 const isLocalVideo = computed(() => video.value?.source !== 'preview')
+const isThirdParty = computed(() => Boolean(route.query.platform))
 
 const actions = computed(() => {
   if (video.value?.is_deleted) {
@@ -671,6 +682,7 @@ const preferredCoverPath = computed(() => {
 const preferredCoverUrl = computed(() => getCoverUrl({
   cover_path_local: String(video.value?.cover_path_local || '').trim(),
   cover_path: String(video.value?.cover_path || '').trim() || preferredCoverPath.value,
+  cover_url: String(video.value?.cover_url || '').trim(),
   local_cover_asset_version: String(video.value?.local_cover_asset_version || '').trim()
 }))
 const preferredThumbnailImages = computed(() => {
@@ -1278,32 +1290,76 @@ async function loadVideo() {
   clearAssetRefreshTimer()
   assetRefreshAttempts.value = 0
   loading.value = true
+  const platform = route.query.platform
+  const isThirdPartyDetail = Boolean(platform)
   try {
-    const data = await videoStore.fetchDetail(videoId.value)
-    video.value = data
-    showMagnets.value = false
-    if (data?.score) {
-      scoreValue.value = data.score
+    if (isThirdPartyDetail) {
+      // 第三方视频：通过第三方 API 获取详情
+      try {
+        const res = await videoApi.thirdPartyDetail(videoId.value, { platform })
+        if (res.code === 200 && res.data) {
+          const raw = res.data
+          // 标准化 tags：若为字符串数组则转为 {id, name} 对象数组
+          if (Array.isArray(raw.tags)) {
+            raw.tags = raw.tags
+              .map((tag, index) => {
+                if (typeof tag === 'string') {
+                  const name = tag.trim()
+                  if (!name) return null
+                  return { id: `tp-${index}`, name }
+                }
+                if (tag && typeof tag === 'object') {
+                  const name = String(tag.name || '').trim()
+                  if (!name) return null
+                  return { ...tag, name }
+                }
+                return null
+              })
+              .filter(Boolean)
+          }
+          video.value = { ...raw, source: 'preview' }
+          if (raw?.score) {
+            scoreValue.value = raw.score
+          }
+          syncEditFormFromVideo(raw)
+          syncPrimarySourceSelection(raw)
+          syncPreviewAssetSelection(raw)
+          syncThumbnailSelectionState(raw)
+        } else {
+          video.value = null
+        }
+      } catch {
+        video.value = null
+      }
+    } else {
+      const data = await videoStore.fetchDetail(videoId.value)
+      video.value = data
+      showMagnets.value = false
+      if (data?.score) {
+        scoreValue.value = data.score
+      }
+      if (data?.list_ids) {
+        selectedListIds.value = [...data.list_ids]
+      }
+      selectedTagIds.value = [...(data?.tag_ids || [])]
+      syncEditFormFromVideo(data)
+      syncPrimarySourceSelection(data)
+      syncPreviewAssetSelection(data)
+      syncThumbnailSelectionState(data)
+      scheduleLocalAssetRefresh()
     }
-    if (data?.list_ids) {
-      selectedListIds.value = [...data.list_ids]
-    }
-    selectedTagIds.value = [...(data?.tag_ids || [])]
-    syncEditFormFromVideo(data)
-    syncPrimarySourceSelection(data)
-    syncPreviewAssetSelection(data)
-    syncThumbnailSelectionState(data)
-    scheduleLocalAssetRefresh()
   } finally {
     loading.value = false
   }
 
-  Promise.allSettled([
-    listStore.fetchLists('video'),
-    actorStore.fetchList()
-  ]).catch((error) => {
-    console.warn('加载附加数据失败:', error)
-  })
+  if (!isThirdPartyDetail) {
+    Promise.allSettled([
+      listStore.fetchLists('video'),
+      actorStore.fetchList()
+    ]).catch((error) => {
+      console.warn('加载附加数据失败:', error)
+    })
+  }
 
   if (route.query.autoplay === '1') {
     loadPlayUrls()
@@ -1758,6 +1814,11 @@ async function loadPlayUrls(options = {}) {
     }
     if (playbackSource === 'remote' && options.providerKey) {
       params.remote_provider = options.providerKey
+    }
+    // 第三方视频传递 platform 参数
+    const platform = route.query.platform
+    if (platform) {
+      params.platform = platform
     }
     const response = await videoStore.getPlayUrls(videoId.value, params)
     if (!options.silentLoading) {

--- a/comic_frontend/src/views/search/GlobalSearch.vue
+++ b/comic_frontend/src/views/search/GlobalSearch.vue
@@ -19,8 +19,28 @@
 
       <div class="search-subtitle">仅搜索全网内容，输入关键词后点击搜索或按回车触发。</div>
 
+      <!-- 平台选择器（多选） -->
+      <div v-if="platformOptions.length > 0" class="platform-selector">
+        <div
+          class="platform-chip"
+          :class="{ active: selectedPlatforms.length === 0 }"
+          @click="handlePlatformChange('all')"
+        >
+          全部
+        </div>
+        <div
+          v-for="opt in platformOptions"
+          :key="opt.platform"
+          class="platform-chip"
+          :class="{ active: selectedPlatforms.includes(opt.platform) }"
+          @click="handlePlatformChange(opt.platform)"
+        >
+          {{ opt.label }}
+        </div>
+      </div>
+
       <div v-if="isVideoMode" class="tag-search-entry">
-        <van-button size="small" plain type="primary" icon="filter-o" @click="goToVideoTagSearch">
+        <van-button size="small" plain type="primary" icon="filter-o" @click="goToTagSearch">
           标签搜索
         </van-button>
       </div>
@@ -63,7 +83,7 @@
               <div v-if="isSelected(item)" class="select-overlay">
                 <van-icon name="success" class="select-icon" />
               </div>
-              <div v-if="!isVideoMode" class="card-hover-actions">
+              <div class="card-hover-actions">
                 <div class="hover-action-btn" title="查看详情" @click.stop="goToDetail(item)">
                   <van-icon name="eye-o" />
                 </div>
@@ -116,10 +136,10 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { useModeStore, useComicStore, useImportTaskStore } from '@/stores'
-import { videoApi } from '@/api'
+import { storeToRefs } from 'pinia'
+import { useModeStore, useComicStore, useImportTaskStore, useVideoStore, useGlobalSearchStore } from '@/stores'
 import EmptyState from '@/components/common/EmptyState.vue'
 import { showConfirmDialog, showToast } from 'vant'
 import {
@@ -137,18 +157,27 @@ import {
 const router = useRouter()
 const modeStore = useModeStore()
 const comicStore = useComicStore()
+const videoStore = useVideoStore()
 const importTaskStore = useImportTaskStore()
+const searchStore = useGlobalSearchStore()
 
-const keyword = ref('')
+// 持久化状态 — 来自 store，页面导航间保持
+const {
+  keyword,
+  results,
+  hasMore,
+  currentPage,
+  selectedIds,
+  paginationInfo,
+  searchExecuted,
+  selectedPlatforms,
+  platformOptions,
+} = storeToRefs(searchStore)
+
+// 临时 UI 状态 — 组件销毁即消失
 const loading = ref(false)
 const loadingMore = ref(false)
-const results = ref([])
-const hasMore = ref(false)
-const currentPage = ref(0)
-const selectedIds = ref([])
 const showImportSheet = ref(false)
-const paginationInfo = ref(null)
-const searchExecuted = ref(false)
 
 const isVideoMode = computed(() => modeStore.isVideoMode)
 
@@ -240,7 +269,8 @@ function goToDetail(item) {
       console.warn('[goToDetail] 无法解析平台信息:', item)
       return
     }
-    router.push({ name: 'ComicDetail', params: { id }, query: { platform } })
+    const routeName = isVideoMode.value ? 'VideoDetail' : 'ComicDetail'
+    router.push({ name: routeName, params: { id }, query: { platform } })
   }
 }
 
@@ -248,7 +278,7 @@ function toggleSelectAllRemote() {
   toggleSelectAll(selectedIds, normalizedResults.value, (item) => getItemId(item))
 }
 
-async function goToVideoTagSearch() {
+async function goToTagSearch() {
   try {
     const platformOptions = await fetchProtocolPlatformOptions({
       mediaType: 'video',
@@ -259,26 +289,14 @@ async function goToVideoTagSearch() {
       throw new Error('当前没有声明标签搜索能力的视频平台')
     }
 
-    const res = await videoApi.thirdPartyPlatformHealthStatus(targetPlatform.platform)
-    const configured = Boolean(res?.code === 200 && res?.data?.configured)
-    if (configured) {
-      router.push({
-        path: '/video-tag-search',
-        query: { platform: targetPlatform.platform }
-      })
-      return
-    }
-
-    await showConfirmDialog({
-      title: '提示',
-      message: `未完成 ${targetPlatform.label} 所需配置，请先在系统设置中完成配置`,
-      showCancelButton: false,
-      confirmButtonText: '知道了'
+    router.push({
+      name: 'VideoTagSearch',
+      query: { platform: targetPlatform.platform }
     })
   } catch (e) {
     await showConfirmDialog({
       title: '提示',
-      message: e?.message || '当前没有可用的标签搜索平台',
+      message: e?.message || '当前没有可用的视频标签搜索平台',
       showCancelButton: false,
       confirmButtonText: '知道了'
     })
@@ -287,6 +305,25 @@ async function goToVideoTagSearch() {
 
 function handleImport() {
   showImportSheet.value = true
+}
+
+function handlePlatformChange(platform) {
+  if (platform === 'all') {
+    // 点击"全部" → 清空选择 → 搜全部平台
+    selectedPlatforms.value = []
+  } else {
+    // 切换单个平台选/不选
+    const idx = selectedPlatforms.value.indexOf(platform)
+    if (idx >= 0) {
+      selectedPlatforms.value.splice(idx, 1)
+    } else {
+      selectedPlatforms.value.push(platform)
+    }
+  }
+  // 若有关键词则自动重新搜索
+  if (String(keyword.value || '').trim()) {
+    handleSearch()
+  }
 }
 
 async function confirmImport(target) {
@@ -326,7 +363,7 @@ async function confirmImport(target) {
       throw new Error('未找到可导入的平台标识')
     }
     showToast(`已创建 ${taskCount} 个导入任务`)
-    selectedIds.value = []
+    searchStore.clearSelection()
   } catch {
     showToast('导入失败')
   }
@@ -356,27 +393,36 @@ async function handleSearch() {
 }
 
 async function searchRemote(searchKeyword) {
+  const platform = selectedPlatforms.value.length > 0 ? selectedPlatforms.value.join(',') : 'all'
   if (isVideoMode.value) {
-    const res = await videoApi.thirdPartySearch(searchKeyword, 1)
-    if (res.code === 200 && res.data) {
-      results.value = res.data.videos || []
-      paginationInfo.value = {
-        platform: res.data.platform,
-        page: res.data.page,
-        total_pages: res.data.total_pages,
-        has_next: res.data.has_next
-      }
-      hasMore.value = res.data.has_next
+    const res = await videoStore.thirdPartySearch(searchKeyword, platform, 1, 40)
+    if (res.results) {
+      searchStore.setSearchState({
+        keyword: searchKeyword,
+        results: res.results,
+        currentPage: res.page,
+        hasMore: res.has_more,
+        paginationInfo: {
+          platform: res.platform || 'all',
+          page: res.page || 1,
+          total_pages: res.total_pages || 1,
+        },
+        videoMode: true,
+      })
     }
     return
   }
 
-  const res = await comicStore.thirdPartySearch(searchKeyword, 'all', 1, 40)
+  const res = await comicStore.thirdPartySearch(searchKeyword, platform, 1, 40)
   if (res.results) {
-    results.value = res.results
-    currentPage.value = res.page
-    hasMore.value = res.has_more
-    paginationInfo.value = res.platform_info || {}
+    searchStore.setSearchState({
+      keyword: searchKeyword,
+      results: res.results,
+      currentPage: res.page,
+      hasMore: res.has_more,
+      paginationInfo: res.platform_info || {},
+      videoMode: false,
+    })
   }
 }
 
@@ -390,43 +436,60 @@ async function loadMore() {
       return
     }
 
+    const platform = selectedPlatforms.value.length > 0 ? selectedPlatforms.value.join(',') : 'all'
+
     if (isVideoMode.value) {
-      const nextPage = paginationInfo.value ? paginationInfo.value.page + 1 : 2
-      const res = await videoApi.thirdPartySearch(normalizedKeyword, nextPage)
-      if (res.code === 200 && res.data) {
-        results.value = [...results.value, ...(res.data.videos || [])]
-        paginationInfo.value = {
-          platform: res.data.platform,
-          page: res.data.page,
-          total_pages: res.data.total_pages,
-          has_next: res.data.has_next
-        }
-        hasMore.value = res.data.has_next
+      const nextPage = currentPage.value + 1
+      const res = await videoStore.thirdPartySearch(normalizedKeyword, platform, nextPage, 40)
+      if (res.results) {
+        searchStore.appendResults(res.results, res.page, res.has_more, res.platform_info)
       }
       return
     }
 
     const nextPage = currentPage.value + 1
-    const res = await comicStore.thirdPartySearch(normalizedKeyword, 'all', nextPage, 40)
+    const res = await comicStore.thirdPartySearch(normalizedKeyword, platform, nextPage, 40)
     if (res.results) {
-      results.value = [...results.value, ...res.results]
-      currentPage.value = res.page
-      hasMore.value = res.has_more
-      paginationInfo.value = res.platform_info || {}
+      searchStore.appendResults(res.results, res.page, res.has_more, res.platform_info || {})
     }
   } finally {
     loadingMore.value = false
   }
 }
 
+/** 加载当前模式下的平台选项 */
+async function loadPlatformOptions(mediaType) {
+  try {
+    const options = await fetchProtocolPlatformOptions({
+      mediaType,
+      capability: 'catalog.search',
+    })
+    platformOptions.value = options.map((item) => ({
+      platform: item.platform,
+      label: item.label,
+    }))
+  } catch (e) {
+    console.warn('[GlobalSearch] 加载平台选项失败:', e)
+  }
+}
+
+// 监听视频/漫画模式切换：模式变化时清空数据、刷新平台列表
+watch(isVideoMode, async (newMode, oldMode) => {
+  const modeChanged = oldMode !== undefined && newMode !== oldMode
+  if (modeChanged) {
+    // 模式真正切换了 → 清空结果和平台选择
+    searchStore.clearResults()
+    selectedPlatforms.value = []
+    platformOptions.value = []
+    await loadPlatformOptions(newMode ? 'video' : 'comic')
+  } else if (platformOptions.value.length === 0) {
+    // 首次挂载或选项已丢失时加载
+    await loadPlatformOptions(newMode ? 'video' : 'comic')
+  }
+}, { immediate: true })
+
 onMounted(() => {
-  keyword.value = ''
-  results.value = []
-  hasMore.value = false
-  currentPage.value = 0
-  selectedIds.value = []
-  paginationInfo.value = null
-  searchExecuted.value = false
+  // onMounted 不再处理 —— watch 的 immediate: true 已覆盖
 })
 </script>
 
@@ -484,9 +547,48 @@ onMounted(() => {
   color: var(--text-tertiary);
 }
 
+.platform-selector {
+  display: flex;
+  gap: 8px;
+  padding: 0 14px 10px;
+  overflow-x: auto;
+  flex-shrink: 0;
+  scrollbar-width: none;
+}
+
+.platform-selector::-webkit-scrollbar {
+  display: none;
+}
+
+.platform-chip {
+  flex-shrink: 0;
+  padding: 4px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--surface-3);
+  border: 1px solid var(--border-soft);
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.platform-chip:hover {
+  border-color: var(--brand-400);
+  color: var(--brand-500);
+}
+
+.platform-chip.active {
+  background: var(--brand-500);
+  border-color: var(--brand-500);
+  color: #fff;
+}
+
 .tag-search-entry {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   padding: 0 12px 10px;
 }
 

--- a/comic_frontend/src/views/search/VideoTagSearch.vue
+++ b/comic_frontend/src/views/search/VideoTagSearch.vue
@@ -8,171 +8,171 @@
     </div>
   </div>
 
-  <template>
-      <van-loading v-if="!platformsLoaded || !platformStatusChecked" class="loading-center" />
+  <van-loading v-if="!platformsLoaded || !platformStatusChecked" class="loading-center" />
 
-      <div v-else-if="availablePlatforms.length === 0" class="mode-empty">
-        <EmptyState
-          title="暂无可用平台"
-          :description="`当前没有声明标签搜索能力的${isVideoMode ? '视频' : '漫画'}插件`"
-        />
+  <div v-else-if="availablePlatforms.length === 0" class="mode-empty">
+    <EmptyState
+      title="暂无可用平台"
+      :description="`当前没有声明标签搜索能力的${isVideoMode ? '视频' : '漫画'}插件`"
+    />
+  </div>
+
+  <div v-else-if="!platformConfigured" class="mode-empty">
+    <EmptyState
+      title="未完成平台配置"
+      :description="platformConfigMessage"
+    />
+  </div>
+
+  <template v-else>
+    <div v-if="availablePlatforms.length > 1" class="platform-switch">
+      <button
+        v-for="platform in availablePlatforms"
+        :key="platform.platform"
+        type="button"
+        class="platform-pill"
+        :class="{ active: selectedPlatform === platform.platform }"
+        @click="selectPlatform(platform.platform)"
+      >
+        {{ platform.label }}
+      </button>
+    </div>
+
+    <div class="filters-card">
+    <div class="filter-actions">
+      <span class="selected-summary">已选 {{ selectedTagIds.length }} 个标签</span>
+      <div class="filter-action-btns">
+        <van-button
+          size="small"
+          plain
+          :disabled="selectedTagIds.length === 0"
+          @click="clearSelectedTags"
+        >
+          清空
+        </van-button>
+        <van-button
+          size="small"
+          type="primary"
+          :disabled="selectedTagIds.length === 0 || loadingTags"
+          :loading="loading"
+          @click="handleSearch"
+        >
+          搜索
+        </van-button>
       </div>
+    </div>
 
-      <div v-else-if="!platformConfigured" class="mode-empty">
-        <EmptyState
-          title="未完成平台配置"
-          :description="platformConfigMessage"
-        />
-      </div>
+    <div v-if="selectedTags.length > 0" class="selected-tags">
+      <van-tag
+        v-for="tag in selectedTags"
+        :key="tag.id"
+        closeable
+        type="primary"
+        @close="removeSelectedTag(tag.id)"
+      >
+        {{ tag.name }}
+      </van-tag>
+    </div>
 
-      <template v-else>
-        <div v-if="availablePlatforms.length > 1" class="platform-switch">
+    <van-loading v-if="loadingTags" class="loading-center" />
+
+    <template v-else>
+      <div class="tags-container">
+        <van-tabs v-model:active="activeCategory" shrink>
+          <van-tab
+            v-for="category in categoryTabs"
+            :key="category.key"
+            :title="`${category.name} (${category.count})`"
+            :name="category.key"
+          />
+        </van-tabs>
+
+        <div class="tag-grid">
           <button
-            v-for="platform in availablePlatforms"
-            :key="platform.platform"
-            type="button"
-            class="platform-pill"
-            :class="{ active: selectedPlatform === platform.platform }"
-            @click="selectPlatform(platform.platform)"
-          >
-            {{ platform.label }}
-          </button>
-        </div>
-
-        <div class="filters-card">
-        <div class="filter-actions">
-          <span class="selected-summary">已选 {{ selectedTagIds.length }} 个标签</span>
-          <div class="filter-action-btns">
-            <van-button
-              size="small"
-              plain
-              :disabled="selectedTagIds.length === 0"
-              @click="clearSelectedTags"
-            >
-              清空
-            </van-button>
-            <van-button
-              size="small"
-              type="primary"
-              :disabled="selectedTagIds.length === 0 || loadingTags"
-              :loading="loading"
-              @click="handleSearch"
-            >
-              搜索
-            </van-button>
-          </div>
-        </div>
-
-        <div v-if="selectedTags.length > 0" class="selected-tags">
-          <van-tag
-            v-for="tag in selectedTags"
+            v-for="tag in filteredTags"
             :key="tag.id"
-            closeable
-            type="primary"
-            @close="removeSelectedTag(tag.id)"
+            type="button"
+            class="tag-pill"
+            :class="{ selected: selectedTagIds.includes(tag.id) }"
+            @click="toggleTag(tag.id)"
           >
             {{ tag.name }}
-          </van-tag>
+          </button>
         </div>
+      </div>
+    </template>
+  </div>
 
-        <van-loading v-if="loadingTags" class="loading-center" />
+    <div class="results-card">
+    <div class="results-header">
+      <span class="results-title">搜索结果</span>
+      <span v-if="searchExecuted" class="results-count">{{ normalizedResults.length }} 项</span>
+    </div>
 
-        <template v-else>
-          <van-tabs v-model:active="activeCategory" shrink>
-            <van-tab
-              v-for="category in categoryTabs"
-              :key="category.key"
-              :title="`${category.name} (${category.count})`"
-              :name="category.key"
-            />
-          </van-tabs>
+    <van-loading v-if="loading" class="loading-center" />
 
-          <div class="tag-grid">
-            <button
-              v-for="tag in filteredTags"
-              :key="tag.id"
-              type="button"
-              class="tag-pill"
-              :class="{ selected: selectedTagIds.includes(tag.id) }"
-              @click="toggleTag(tag.id)"
-            >
-              {{ tag.name }}
-            </button>
-          </div>
-        </template>
+    <EmptyState
+      v-else-if="searchExecuted && normalizedResults.length === 0"
+      title="未找到结果"
+      description="尝试调整标签组合后重新搜索"
+    />
+
+    <EmptyState
+      v-else-if="!searchExecuted"
+      title="先选标签再搜索"
+      :description="`标签来源于 ${currentPlatformLabel} 内置标签能力`"
+    />
+
+    <div v-else class="results-container">
+      <div class="remote-select-bar">
+        <span class="selected-count">已选 {{ selectedResultIds.length }} 项</span>
+        <van-button size="small" plain type="primary" @click="toggleSelectAllResults">
+          {{ isAllResultsSelected ? '取消全选' : '全选' }}
+        </van-button>
       </div>
 
-        <div class="results-card">
-        <div class="results-header">
-          <span class="results-title">搜索结果</span>
-          <span v-if="searchExecuted" class="results-count">{{ normalizedResults.length }} 项</span>
-        </div>
-
-        <van-loading v-if="loading" class="loading-center" />
-
-        <EmptyState
-          v-else-if="searchExecuted && normalizedResults.length === 0"
-          title="未找到结果"
-          description="尝试调整标签组合后重新搜索"
-        />
-
-        <EmptyState
-          v-else-if="!searchExecuted"
-          title="先选标签再搜索"
-          :description="`标签来源于 ${currentPlatformLabel} 内置标签能力`"
-        />
-
-        <div v-else class="results-container">
-          <div class="remote-select-bar">
-            <span class="selected-count">已选 {{ selectedResultIds.length }} 项</span>
-            <van-button size="small" plain type="primary" @click="toggleSelectAllResults">
-              {{ isAllResultsSelected ? '取消全选' : '全选' }}
-            </van-button>
-          </div>
-
-          <div class="remote-results-grid" :class="isVideoMode ? 'video-mode' : 'comic-mode'">
-            <div
-              v-for="item in normalizedResults"
-              :key="getItemId(item)"
-              class="remote-result-card"
-              :class="{ selected: isResultSelected(item) }"
-              @click="toggleResultSelection(item)"
-            >
-              <div
-                class="card-cover"
-                :style="getCardCoverStyle(item)"
-              >
-                <van-image
-                  :src="getCoverUrl(item)"
-                  :fit="getCardCoverFit(item)"
-                  class="cover-image"
-                  lazy-load
-                />
-                <div v-if="shouldRenderPlatformBadge(item)" class="platform-badge">{{ getPlatformBadgeLabel(item) }}</div>
-                <div v-if="item.score" class="card-score score-badge">{{ formatScore(item.score) }}</div>
-                <div v-if="isResultSelected(item)" class="select-overlay">
-                  <van-icon name="success" class="select-icon" />
-                </div>
-              </div>
-              <div class="card-info">
-                <div class="card-title">{{ item.title }}</div>
-                <div v-if="item.code" class="card-code">{{ item.code }}</div>
-              </div>
+      <div class="remote-results-grid" :class="isVideoMode ? 'video-mode' : 'comic-mode'">
+        <div
+          v-for="item in normalizedResults"
+          :key="getItemId(item)"
+          class="remote-result-card"
+          :class="{ selected: isResultSelected(item) }"
+          @click="toggleResultSelection(item)"
+        >
+          <div
+            class="card-cover"
+            :style="getCardCoverStyle(item)"
+          >
+            <van-image
+              :src="getCoverUrl(item)"
+              :fit="getCardCoverFit(item)"
+              class="cover-image"
+              lazy-load
+            />
+            <div v-if="shouldRenderPlatformBadge(item)" class="platform-badge">{{ getPlatformBadgeLabel(item) }}</div>
+            <div v-if="item.score" class="card-score score-badge">{{ formatScore(item.score) }}</div>
+            <div v-if="isResultSelected(item)" class="select-overlay">
+              <van-icon name="success" class="select-icon" />
             </div>
           </div>
-
-          <div v-if="hasMore" class="load-more">
-            <div v-if="paginationInfo" class="pagination-info">
-              <span class="page-info">第 {{ paginationInfo.page }} 页</span>
-            </div>
-            <van-button block plain :loading="loadingMore" @click="loadMore">
-              加载更多
-            </van-button>
+          <div class="card-info">
+            <div class="card-title">{{ item.title }}</div>
+            <div v-if="item.code" class="card-code">{{ item.code }}</div>
           </div>
         </div>
+      </div>
+
+      <div v-if="hasMore" class="load-more">
+        <div v-if="paginationInfo" class="pagination-info">
+          <span class="page-info">第 {{ paginationInfo.page }} 页</span>
         </div>
-      </template>
-    </template>
+        <van-button block plain :loading="loadingMore" @click="loadMore">
+          加载更多
+        </van-button>
+      </div>
+    </div>
+    </div>
+  </template>
 
     <div v-if="selectedResultIds.length > 0" class="floating-import-bar">
       <span class="floating-selection-info">已选 {{ selectedResultIds.length }} 项</span>
@@ -189,7 +189,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useModeStore, useImportTaskStore } from '@/stores'
 import { uiStateApi, videoApi } from '@/api'
@@ -268,19 +268,43 @@ function buildPersistedStatePayload() {
   }
 }
 
+/** 给 API 调用包装超时，防止长时间阻塞 */
+async function withTimeout(promise, timeoutMs = 3000) {
+  return Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`API timeout after ${timeoutMs}ms`)), timeoutMs)
+    )
+  ])
+}
+
 async function persistViewState() {
-  const payload = buildPersistedStatePayload()
-  if (!payload) {
-    await uiStateApi.clear(getUiStateScope(), uiStateClientId)
-    return
+  try {
+    const payload = buildPersistedStatePayload()
+    if (!payload) {
+      await withTimeout(uiStateApi.clear(getUiStateScope(), uiStateClientId))
+      return
+    }
+    await withTimeout(uiStateApi.save(getUiStateScope(), payload, uiStateClientId))
+  } catch (e) {
+    console.warn('[VideoTagSearch] persistViewState 失败（非关键错误）:', e)
   }
-  await uiStateApi.save(getUiStateScope(), payload, uiStateClientId)
 }
 
 async function restoreViewState() {
-  const response = await uiStateApi.get(getUiStateScope(), uiStateClientId)
+  const response = await withTimeout(uiStateApi.get(getUiStateScope(), uiStateClientId))
   const state = response?.data?.state
   return state && typeof state === 'object' ? state : null
+}
+
+/** 带超时的 restoreViewState，防止后端无响应时阻塞初始化长达分钟级别 */
+async function restoreViewStateWithTimeout(timeoutMs = 5000) {
+  return Promise.race([
+    restoreViewState(),
+    new Promise((_, reject) =>
+      setTimeout(() => reject(new Error(`restoreViewState timeout after ${timeoutMs}ms`)), timeoutMs)
+    )
+  ])
 }
 
 const categoryTabs = computed(() => {
@@ -672,11 +696,33 @@ async function confirmImport(target) {
 }
 
 onMounted(async () => {
-  const restoredState = await restoreViewState()
+  let restoredState = null
+  try {
+    restoredState = await restoreViewStateWithTimeout(5000)
+  } catch (e) {
+    console.warn('[VideoTagSearch] restoreViewState 失败（非关键错误）:', e)
+  }
   await loadAvailablePlatforms(restoredState)
+  await nextTick()
   if (Array.isArray(selectedTagIds.value) && selectedTagIds.value.length > 0) {
     await handleSearch()
   }
+})
+
+// 安全兜底：防止 loading 状态卡死，5 秒后强制显示内容（无论平台是否就绪）
+let safetyTimer = null
+onMounted(() => {
+  safetyTimer = setTimeout(() => {
+    if (platformStatusChecked.value === false && platformsLoaded.value === true) {
+      platformStatusChecked.value = true
+      platformConfigured.value = true
+      loadingTags.value = false
+      console.warn('[VideoTagSearch] 平台配置检查超时，强制进入可用状态')
+    }
+  }, 5000)
+})
+onUnmounted(() => {
+  if (safetyTimer) clearTimeout(safetyTimer)
 })
 </script>
 
@@ -796,12 +842,16 @@ onMounted(async () => {
 }
 
 .tag-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
-  max-height: 44vh;
-  overflow-y: auto;
   padding-top: 10px;
+  min-height: 36px;
+}
+
+.tags-container {
+  display: block;
+  width: 100%;
 }
 
 .tag-pill {

--- a/comic_frontend/src/views/search/VideoTagSearch.vue
+++ b/comic_frontend/src/views/search/VideoTagSearch.vue
@@ -3,25 +3,18 @@
     <div class="page-header">
       <van-icon name="arrow-left" class="back-icon" @click="$router.back()" />
       <div class="header-copy">
-        <div class="header-title">{{ currentPlatformLabel }} 标签搜索</div>
-        <div class="header-subtitle">多选平台内置标签后搜索并导入</div>
-      </div>
+      <div class="header-title">{{ currentPlatformLabel }} 标签搜索</div>
+      <div class="header-subtitle">多选平台内置标签后搜索并导入</div>
     </div>
+  </div>
 
-    <div v-if="!isVideoMode" class="mode-empty">
-      <EmptyState title="仅视频模式可用" description="请先切换到视频模式" />
-      <van-button type="primary" class="mode-switch-btn" @click="switchToVideoMode">
-        切换到视频模式
-      </van-button>
-    </div>
-
-    <template v-else>
+  <template>
       <van-loading v-if="!platformsLoaded || !platformStatusChecked" class="loading-center" />
 
       <div v-else-if="availablePlatforms.length === 0" class="mode-empty">
         <EmptyState
           title="暂无可用平台"
-          description="当前没有声明标签搜索能力的视频插件"
+          :description="`当前没有声明标签搜索能力的${isVideoMode ? '视频' : '漫画'}插件`"
         />
       </div>
 
@@ -137,7 +130,7 @@
             </van-button>
           </div>
 
-          <div class="remote-results-grid video-mode">
+          <div class="remote-results-grid" :class="isVideoMode ? 'video-mode' : 'comic-mode'">
             <div
               v-for="item in normalizedResults"
               :key="getItemId(item)"
@@ -181,7 +174,7 @@
       </template>
     </template>
 
-    <div v-if="selectedResultIds.length > 0 && isVideoMode" class="floating-import-bar">
+    <div v-if="selectedResultIds.length > 0" class="floating-import-bar">
       <span class="floating-selection-info">已选 {{ selectedResultIds.length }} 项</span>
       <van-button type="primary" @click="showImportSheet = true">导入选中</van-button>
     </div>
@@ -200,6 +193,7 @@ import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useModeStore, useImportTaskStore } from '@/stores'
 import { uiStateApi, videoApi } from '@/api'
+import { comicApi } from '@/api/comic'
 import EmptyState from '@/components/common/EmptyState.vue'
 import { showConfirmDialog, showToast } from 'vant'
 import {
@@ -222,6 +216,7 @@ const modeStore = useModeStore()
 const importTaskStore = useImportTaskStore()
 
 const isVideoMode = computed(() => modeStore.isVideoMode)
+const tagApi = computed(() => isVideoMode.value ? videoApi : comicApi)
 
 const loadingTags = ref(false)
 const loading = ref(false)
@@ -257,7 +252,7 @@ const platformConfigMessage = computed(() => {
 })
 
 function getUiStateScope() {
-  return buildUiStateScope('video_tag_search', true)
+  return buildUiStateScope(isVideoMode.value ? 'video_tag_search' : 'comic_tag_search', true)
 }
 
 function buildPersistedStatePayload() {
@@ -361,7 +356,7 @@ async function ensurePlatformConfigured(showDialog = false) {
   }
 
   try {
-    const res = await videoApi.thirdPartyPlatformHealthStatus(platform)
+    const res = await tagApi.value.thirdPartyPlatformHealthStatus(platform)
     const configured = Boolean(res?.code === 200 && res?.data?.configured)
     platformConfigured.value = configured
     platformStatusChecked.value = true
@@ -396,11 +391,6 @@ async function ensurePlatformConfigured(showDialog = false) {
     }
     return false
   }
-}
-
-async function switchToVideoMode() {
-  modeStore.setMode('video')
-  await loadAvailablePlatforms()
 }
 
 async function toggleTag(tagId) {
@@ -485,7 +475,7 @@ async function loadAvailablePlatforms(restoredState = null) {
   platformsLoaded.value = false
   try {
     const options = await fetchProtocolPlatformOptions({
-      mediaType: 'video',
+      mediaType: isVideoMode.value ? 'video' : 'comic',
       capability: 'taxonomy.tag_search'
     })
     availablePlatforms.value = options
@@ -519,11 +509,11 @@ async function selectPlatform(platform) {
 }
 
 async function loadTags(restoredState = null) {
-  if (!isVideoMode.value || !platformConfigured.value || !platformStatusChecked.value) return
+  if (!platformConfigured.value || !platformStatusChecked.value) return
 
   loadingTags.value = true
   try {
-    const res = await videoApi.thirdPartyPlatformTags(selectedPlatform.value)
+    const res = await tagApi.value.thirdPartyPlatformTags(selectedPlatform.value)
     if (res.code === 200 && res.data) {
       if (res.data.cookie_configured === false) {
         platformConfigured.value = false
@@ -589,9 +579,9 @@ async function handleSearch() {
   paginationInfo.value = null
 
   try {
-    const res = await videoApi.thirdPartyPlatformSearchByTags(selectedPlatform.value, selectedTagIds.value, 1)
+    const res = await tagApi.value.thirdPartyPlatformSearchByTags(selectedPlatform.value, selectedTagIds.value, 1)
     if (res.code === 200 && res.data) {
-      results.value = res.data.videos || []
+      results.value = res.data.videos || res.data.albums || []
       paginationInfo.value = {
         page: res.data.page || 1
       }
@@ -618,9 +608,9 @@ async function loadMore() {
   loadingMore.value = true
   try {
     const nextPage = (paginationInfo.value?.page || 1) + 1
-    const res = await videoApi.thirdPartyPlatformSearchByTags(selectedPlatform.value, selectedTagIds.value, nextPage)
+    const res = await tagApi.value.thirdPartyPlatformSearchByTags(selectedPlatform.value, selectedTagIds.value, nextPage)
     if (res.code === 200 && res.data) {
-      results.value = [...results.value, ...(res.data.videos || [])]
+      results.value = [...results.value, ...(res.data.videos || res.data.albums || [])]
       paginationInfo.value = {
         page: res.data.page || nextPage
       }
@@ -646,24 +636,26 @@ async function confirmImport(target) {
   }
 
   const itemsByPlatform = {}
+  const idFieldName = isVideoMode.value ? 'video_ids' : 'comic_ids'
+  const contentType = isVideoMode.value ? 'video' : 'comic'
   selectedItems.forEach(item => {
     const platform = String(resolveImportPlatform(item) || selectedPlatform.value || '').trim().toUpperCase()
-    const videoId = getItemId(item)
-    if (!videoId) return
+    const itemId = getItemId(item)
+    if (!itemId) return
     if (!itemsByPlatform[platform]) {
       itemsByPlatform[platform] = []
     }
-    itemsByPlatform[platform].push(videoId)
+    itemsByPlatform[platform].push(itemId)
   })
 
   let taskCount = 0
-  for (const [platform, videoIds] of Object.entries(itemsByPlatform)) {
+  for (const [platform, itemIds] of Object.entries(itemsByPlatform)) {
     const created = await importTaskStore.createImportTask({
       import_type: 'by_list',
       target,
       platform,
-      comic_ids: videoIds,
-      content_type: 'video'
+      [idFieldName]: itemIds,
+      content_type: contentType
     })
     if (created) {
       taskCount += 1
@@ -878,7 +870,8 @@ onMounted(async () => {
   gap: 10px;
 }
 
-.remote-results-grid.video-mode {
+.remote-results-grid.video-mode,
+.remote-results-grid.comic-mode {
   align-items: start;
 }
 
@@ -890,7 +883,8 @@ onMounted(async () => {
   transition: all 0.16s ease;
 }
 
-.remote-results-grid.video-mode .remote-result-card {
+.remote-results-grid.video-mode .remote-result-card,
+.remote-results-grid.comic-mode .remote-result-card {
   align-self: start;
 }
 
@@ -1032,12 +1026,14 @@ onMounted(async () => {
     aspect-ratio: var(--media-cover-aspect-ratio-mobile, var(--media-cover-aspect-ratio, 2 / 3));
   }
 
-  .remote-results-grid.video-mode .card-title {
+  .remote-results-grid.video-mode .card-title,
+  .remote-results-grid.comic-mode .card-title {
     font-size: 12px;
     min-height: 32px;
   }
 
-  .remote-results-grid.video-mode .card-code {
+  .remote-results-grid.video-mode .card-code,
+  .remote-results-grid.comic-mode .card-code {
     font-size: 11px;
   }
 }

--- a/tests/features/third_party_integration/e2e/video_tag_search_import_contract.spec.js
+++ b/tests/features/third_party_integration/e2e/video_tag_search_import_contract.spec.js
@@ -173,7 +173,7 @@ test("video tag search forwards third-party query and import contracts", async (
     platform: "JAVDB",
     content_type: "video",
   });
-  expect(importTaskBodies[0].comic_ids).toEqual(["JVID-1"]);
+  expect(importTaskBodies[0].video_ids).toEqual(["JVID-1"]);
 
   expect(hasApiCall(requests, "/api/v1/video/third-party/javdb/search-by-tags")).toBeTruthy();
   expect(hasApiCall(requests, "/api/v1/comic/import/async")).toBeTruthy();

--- a/tests/features/third_party_integration/e2e/video_tag_search_pagination_and_recommendation_import.spec.js
+++ b/tests/features/third_party_integration/e2e/video_tag_search_pagination_and_recommendation_import.spec.js
@@ -179,7 +179,7 @@ test("video tag search load more forwards page and imports to recommendation", a
     platform: "JAVDB",
     content_type: "video",
   });
-  expect(importTaskBodies[0].comic_ids).toEqual(["JVID-2"]);
+  expect(importTaskBodies[0].video_ids).toEqual(["JVID-2"]);
 
   expect(hasApiCall(requests, "/api/v1/video/third-party/javdb/search-by-tags")).toBeTruthy();
   expect(hasApiCall(requests, "/api/v1/comic/import/async")).toBeTruthy();


### PR DESCRIPTION

后端: 搜索支持逗号分隔多平台指定，漫画新增 health-status/tags/search-by-tags API

后端: 视频详情/播放源远程获取，代理路由按域名智能分发 + 流式传输

前端 GlobalSearch: 平台选择器(多选)、状态持久化到 Pinia store、双模式详情跳转

前端 VideoTagSearch: 支持漫画模式，根据 mode 切换 API/UI/导入字段

前端 VideoDetail: 支持第三方视频详情加载、预览图、播放链接传递 platform

新增 globalSearch Store 管理搜索结果持久化状态