### PR TITLE
Add minimal Android jmcomic packaging demo

### DIFF
--- a/.github/workflows/android-jmcomic-demo.yml
+++ b/.github/workflows/android-jmcomic-demo.yml
@@ -1,0 +1,51 @@
+name: Android JMComic Demo
+
+on:
+  push:
+    branches:
+      - android-jmcomic-demo
+    paths:
+      - 'android_jmcomic_demo/**'
+      - '.github/workflows/android-jmcomic-demo.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android platform 36
+        run: sdkmanager 'platforms;android-36' 'build-tools;36.0.0'
+
+      - name: Set up Gradle 8.13
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: '8.13'
+
+      - name: Assemble debug APK
+        working-directory: android_jmcomic_demo
+        run: gradle :app:assembleDebug --stacktrace
+
+      - name: Upload APK
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jmcomic-android-demo-debug
+          path: android_jmcomic_demo/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android-jmcomic-demo.yml
+++ b/.github/workflows/android-jmcomic-demo.yml
@@ -7,6 +7,12 @@ on:
     paths:
       - 'android_jmcomic_demo/**'
       - '.github/workflows/android-jmcomic-demo.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'android_jmcomic_demo/**'
+      - '.github/workflows/android-jmcomic-demo.yml'
   workflow_dispatch:
 
 jobs:

--- a/android_jmcomic_demo/README.md
+++ b/android_jmcomic_demo/README.md
@@ -1,0 +1,100 @@
+# JMComic Android Demo
+
+这是一个用于验证 `jmcomic + curl_cffi` 能否被直接打进 Android APK 的最小工程。
+
+它与主项目现有的 `comic_backend` / `comic_frontend` 完全独立，不修改现有架构。
+
+## 技术方案
+
+- Android 原生 Java UI
+- Chaquopy 17.0.0
+- CPython 3.13
+- Android `minSdk 24`
+- 仅支持 `arm64-v8a`
+- `jmcomic`
+- `curl-cffi==0.16.3`
+- `cffi==1.17.1`
+- `Pillow==11.0.0`
+- `pycryptodome==3.21.0`
+- `PyYAML==6.0.2`
+
+之所以固定 ARM64，是因为当前 `curl_cffi` 的 Android 官方 wheel 面向 `android_24_arm64_v8a`。这样可以避免 x86_64 模拟器造成的 ABI 假故障。
+
+## Demo 功能
+
+1. 启动 App。
+2. 点击“环境自检”，验证 Python、`jmcomic`、`curl_cffi` 是否能够在 APK 内正常 import。
+3. 输入 JM 本子 ID。
+4. 点击“下载指定 ID 漫画”。
+5. Python 端调用 `jmcomic.download_album(id, option)`。
+6. 下载文件保存到 App 专属外部目录：
+
+```text
+/storage/emulated/0/Android/data/com.mmtttt.jmcomicdemo/files/Pictures/JMComic/
+```
+
+这个目录不需要申请传统外部存储权限。
+
+## Android Studio 构建
+
+建议使用带 Android SDK 36 的新版 Android Studio，并确保本机安装 Python 3.13。
+
+直接用 Android Studio 打开：
+
+```text
+android_jmcomic_demo/
+```
+
+然后选择真实 ARM64 Android 手机运行。
+
+> 不建议第一步使用 x86_64 Android Emulator，因为当前 Demo 只打包 `arm64-v8a`。
+
+命令行也可以：
+
+```bash
+gradle :app:assembleDebug
+```
+
+生成位置通常为：
+
+```text
+app/build/outputs/apk/debug/app-debug.apk
+```
+
+## 为什么不直接打包 ULTIMATE_WEB 全部后端
+
+主项目 `comic_backend/requirements.txt` 还包含 Flask、lxml、cryptography、py7zr、rarfile 等依赖。直接全量迁移会一次引入太多 native/平台兼容变量。
+
+这个 Demo 先验证最关键链路：
+
+```text
+Android APK
+  -> Chaquopy
+  -> CPython 3.13
+  -> jmcomic
+  -> curl_cffi Android native wheel
+  -> 网络请求 / 图片下载
+```
+
+如果这条链能跑通，再逐步迁移 ULTIMATE_WEB 的业务层会更稳。
+
+## 已知限制
+
+- 仅 ARM64。
+- 下载运行在 App 进程内的后台线程，不是正式版 WorkManager/Foreground Service；切后台或系统杀进程时任务可能中断。
+- 输出目录是 App 专属目录，正式版若要让用户在系统“下载”目录直接管理文件，应接 Storage Access Framework / MediaStore。
+- Demo 只验证单个 JM ID 下载，不包含 ULTIMATE_WEB 的 Web UI、数据库、搜索、任务队列等功能。
+- 能成功 assemble APK 只能证明依赖能打包；最终仍需要真实 Android ARM64 设备验证 `curl_cffi` 的 native `.so` 加载和网络行为。
+
+## 关键文件
+
+```text
+app/build.gradle
+    Chaquopy、Python 版本、ABI 和第三方依赖
+
+app/src/main/python/jm_bridge.py
+    Python -> jmcomic 下载逻辑
+
+app/src/main/java/com/mmtttt/jmcomicdemo/MainActivity.java
+    最小 Android UI / Java -> Python 调用
+```

--- a/android_jmcomic_demo/app/build.gradle
+++ b/android_jmcomic_demo/app/build.gradle
@@ -25,10 +25,18 @@ chaquopy {
     defaultConfig {
         version = '3.13'
         pip {
-            // Pin the native packages to versions known to have Android/Chaquopy wheels.
-            install 'jmcomic'
+            // curl_cffi 0.16.3 declares cffi>=2.0.0, while Chaquopy's
+            // CPython 3.13 Android repository currently provides cffi 1.17.1.
+            // For this PoC we bypass dependency metadata and explicitly install
+            // the runtime set, then verify the combination on a real device.
+            options '--no-deps'
+
+            install 'jmcomic==2.7.5'
+            install 'commonx>=0.6.38'
             install 'curl-cffi==0.16.3'
             install 'cffi==1.17.1'
+            install 'pycparser'
+            install 'certifi'
             install 'Pillow==11.0.0'
             install 'pycryptodome==3.21.0'
             install 'PyYAML==6.0.3'

--- a/android_jmcomic_demo/app/build.gradle
+++ b/android_jmcomic_demo/app/build.gradle
@@ -31,7 +31,7 @@ chaquopy {
             install 'cffi==1.17.1'
             install 'Pillow==11.0.0'
             install 'pycryptodome==3.21.0'
-            install 'PyYAML==6.0.2'
+            install 'PyYAML==6.0.3'
         }
     }
 }

--- a/android_jmcomic_demo/app/build.gradle
+++ b/android_jmcomic_demo/app/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'com.android.application'
+    id 'com.chaquo.python'
+}
+
+android {
+    namespace 'com.mmtttt.jmcomicdemo'
+    compileSdk 36
+
+    defaultConfig {
+        applicationId 'com.mmtttt.jmcomicdemo'
+        minSdk 24
+        targetSdk 36
+        versionCode 1
+        versionName '0.1.0'
+
+        ndk {
+            // curl_cffi currently publishes an Android wheel for ARM64.
+            abiFilters 'arm64-v8a'
+        }
+    }
+}
+
+chaquopy {
+    defaultConfig {
+        version = '3.13'
+        pip {
+            // Pin the native packages to versions known to have Android/Chaquopy wheels.
+            install 'jmcomic'
+            install 'curl-cffi==0.16.3'
+            install 'cffi==1.17.1'
+            install 'Pillow==11.0.0'
+            install 'pycryptodome==3.21.0'
+            install 'PyYAML==6.0.2'
+        }
+    }
+}

--- a/android_jmcomic_demo/app/build.gradle
+++ b/android_jmcomic_demo/app/build.gradle
@@ -29,17 +29,32 @@ chaquopy {
             // CPython 3.13 Android repository currently provides cffi 1.17.1.
             // For this PoC we bypass dependency metadata and explicitly install
             // the runtime set, then verify the combination on a real device.
+            //
+            // IMPORTANT: --no-deps also disables Chaquopy's automatically-added
+            // native support wheels. Keep the chaquopy-* packages below in sync
+            // with the corresponding Chaquopy package recipes.
             options '--no-deps'
 
             install 'jmcomic==2.7.5'
             install 'commonx>=0.6.38'
+
             install 'curl-cffi==0.16.3'
             install 'cffi==1.17.1'
             install 'pycparser'
             install 'certifi'
+            // Required by Chaquopy's cffi Android wheel (_cffi_backend.so).
+            install 'chaquopy-libffi==3.3'
+
             install 'Pillow==11.0.0'
+            // Required by Chaquopy's Pillow 11 Android wheel (_imaging.so).
+            install 'chaquopy-libjpeg==1.5.3'
+            install 'chaquopy-freetype==2.9.1'
+
             install 'pycryptodome==3.21.0'
+
             install 'PyYAML==6.0.3'
+            // Required by Chaquopy's PyYAML Android wheel (_yaml.so).
+            install 'chaquopy-libyaml==0.2.5'
         }
     }
 }

--- a/android_jmcomic_demo/app/src/main/AndroidManifest.xml
+++ b/android_jmcomic_demo/app/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:name="com.chaquo.python.android.PyApplication"
+        android:allowBackup="true"
+        android:label="JMComic Android Demo"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android_jmcomic_demo/app/src/main/java/com/mmtttt/jmcomicdemo/MainActivity.java
+++ b/android_jmcomic_demo/app/src/main/java/com/mmtttt/jmcomicdemo/MainActivity.java
@@ -1,0 +1,149 @@
+package com.mmtttt.jmcomicdemo;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.Environment;
+import android.text.InputType;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import com.chaquo.python.PyObject;
+import com.chaquo.python.Python;
+
+import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class MainActivity extends Activity {
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private EditText idInput;
+    private Button downloadButton;
+    private Button diagnosticsButton;
+    private TextView output;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        int pad = (int) (16 * getResources().getDisplayMetrics().density);
+
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setPadding(pad, pad, pad, pad);
+
+        TextView title = new TextView(this);
+        title.setText("JMComic Android Demo");
+        title.setTextSize(24);
+        root.addView(title);
+
+        TextView hint = new TextView(this);
+        hint.setText("输入 JM 本子 ID。下载目录使用 App 专属 Pictures/JMComic，不需要存储权限。\n建议先点击环境自检。\n");
+        root.addView(hint);
+
+        idInput = new EditText(this);
+        idInput.setHint("例如：438696");
+        idInput.setInputType(InputType.TYPE_CLASS_NUMBER);
+        root.addView(idInput,
+                new LinearLayout.LayoutParams(
+                        LinearLayout.LayoutParams.MATCH_PARENT,
+                        LinearLayout.LayoutParams.WRAP_CONTENT));
+
+        diagnosticsButton = new Button(this);
+        diagnosticsButton.setText("环境自检");
+        diagnosticsButton.setOnClickListener(v -> runDiagnostics());
+        root.addView(diagnosticsButton);
+
+        downloadButton = new Button(this);
+        downloadButton.setText("下载指定 ID 漫画");
+        downloadButton.setOnClickListener(v -> startDownload());
+        root.addView(downloadButton);
+
+        output = new TextView(this);
+        output.setTextIsSelectable(true);
+        output.setText("等待操作…");
+
+        ScrollView scroll = new ScrollView(this);
+        scroll.addView(output);
+        root.addView(scroll, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                0,
+                1f));
+
+        setContentView(root);
+    }
+
+    private void setBusy(boolean busy) {
+        downloadButton.setEnabled(!busy);
+        diagnosticsButton.setEnabled(!busy);
+    }
+
+    private void runDiagnostics() {
+        setBusy(true);
+        output.setText("正在检查 Python / jmcomic / curl_cffi…");
+
+        executor.execute(() -> {
+            String result;
+            try {
+                Python py = Python.getInstance();
+                PyObject module = py.getModule("jm_bridge");
+                result = module.callAttr("diagnostics").toString();
+            } catch (Throwable t) {
+                result = "Java/Chaquopy 调用失败:\n" + android.util.Log.getStackTraceString(t);
+            }
+            final String text = result;
+            runOnUiThread(() -> {
+                output.setText(text);
+                setBusy(false);
+            });
+        });
+    }
+
+    private void startDownload() {
+        String jmId = idInput.getText().toString().trim();
+        if (jmId.isEmpty()) {
+            output.setText("请先输入 JM ID。");
+            return;
+        }
+
+        File pictures = getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        if (pictures == null) {
+            output.setText("无法获取 App 外部文件目录。");
+            return;
+        }
+        File targetDir = new File(pictures, "JMComic");
+
+        setBusy(true);
+        output.setText("开始下载 JM" + jmId + "…\n目录: " + targetDir.getAbsolutePath());
+
+        executor.execute(() -> {
+            String result;
+            try {
+                Python py = Python.getInstance();
+                PyObject module = py.getModule("jm_bridge");
+                result = module.callAttr(
+                        "download_album_by_id",
+                        jmId,
+                        targetDir.getAbsolutePath()
+                ).toString();
+            } catch (Throwable t) {
+                result = "Java/Chaquopy 调用失败:\n" + android.util.Log.getStackTraceString(t);
+            }
+
+            final String text = result;
+            runOnUiThread(() -> {
+                output.setText(text);
+                setBusy(false);
+            });
+        });
+    }
+
+    @Override
+    protected void onDestroy() {
+        executor.shutdownNow();
+        super.onDestroy();
+    }
+}

--- a/android_jmcomic_demo/app/src/main/java/com/mmtttt/jmcomicdemo/MainActivity.java
+++ b/android_jmcomic_demo/app/src/main/java/com/mmtttt/jmcomicdemo/MainActivity.java
@@ -41,7 +41,10 @@ public class MainActivity extends Activity {
         root.addView(title);
 
         TextView hint = new TextView(this);
-        hint.setText("输入 JM 本子 ID。下载目录使用 App 专属 Pictures/JMComic，不需要存储权限。\n建议先点击环境自检。\n");
+        hint.setText(
+                "输入 JM 本子 ID。下载目录使用 App 专属 Pictures/JMComic，不需要存储权限。\n" +
+                "当前启用 Android 安全模式：章节并发=1、图片并发=1、最终保存为 PNG。\n" +
+                "每个章节的图片目录中会生成 jmcomic_android.log，建议先点击环境自检。\n");
         root.addView(hint);
 
         idInput = new EditText(this);
@@ -83,7 +86,7 @@ public class MainActivity extends Activity {
 
     private void runDiagnostics() {
         setBusy(true);
-        output.setText("正在检查 Python / jmcomic / curl_cffi…");
+        output.setText("正在检查 Python / jmcomic / curl_cffi / Pillow / Android 资源状态…");
 
         executor.execute(() -> {
             String result;
@@ -117,7 +120,17 @@ public class MainActivity extends Activity {
         File targetDir = new File(pictures, "JMComic");
 
         setBusy(true);
-        output.setText("开始下载 JM" + jmId + "…\n目录: " + targetDir.getAbsolutePath());
+        output.setText(
+                "开始下载 JM" + jmId + "…\n" +
+                "根目录: " + targetDir.getAbsolutePath() + "\n\n" +
+                "Android 安全模式已启用：\n" +
+                "- 章节并发: 1\n" +
+                "- 图片并发: 1（jmcomic 桌面默认值为 30）\n" +
+                "- WebP: Android BitmapFactory 解码\n" +
+                "- 最终图片: PNG\n\n" +
+                "诊断日志会持续写入实际图片目录中的 jmcomic_android.log。\n" +
+                "在 Python 下载函数返回前，界面不会逐条刷新，请以日志文件和已落盘图片为准。"
+        );
 
         executor.execute(() -> {
             String result;

--- a/android_jmcomic_demo/app/src/main/python/jm_bridge.py
+++ b/android_jmcomic_demo/app/src/main/python/jm_bridge.py
@@ -1,8 +1,142 @@
+import gc
 import json
+import logging
 import os
 import platform
 import sys
+import threading
+import time
 import traceback
+
+
+_ANDROID_LOG_HANDLER = None
+_ACTIVE_LOG_PATH = None
+_LOG_PATHS = []
+_LOG_LOCK = threading.RLock()
+_SAFE_DOWNLOADER_CLASS = None
+
+
+class _SafeLogFormatter(logging.Formatter):
+    def format(self, record):
+        if not hasattr(record, "topic"):
+            record.topic = "python"
+        return super().format(record)
+
+
+class _FsyncFileHandler(logging.FileHandler):
+    """Flush every log record to disk so abrupt process/device death keeps useful traces."""
+
+    def emit(self, record):
+        super().emit(record)
+        try:
+            self.flush()
+            if self.stream is not None:
+                os.fsync(self.stream.fileno())
+        except Exception:
+            # Diagnostics must never break the download path.
+            pass
+
+
+def _configure_jm_file_logging(log_path):
+    global _ANDROID_LOG_HANDLER, _ACTIVE_LOG_PATH
+
+    log_path = os.path.abspath(log_path)
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+
+    with _LOG_LOCK:
+        from jmcomic.jm_config import jm_logger
+
+        old = _ANDROID_LOG_HANDLER
+        if old is not None:
+            try:
+                jm_logger.removeHandler(old)
+                old.close()
+            except Exception:
+                pass
+
+        handler = _FsyncFileHandler(log_path, mode="a", encoding="utf-8")
+        handler._android_demo_file_handler = True
+        handler.setLevel(logging.INFO)
+        handler.setFormatter(
+            _SafeLogFormatter(
+                "[%(asctime)s] [%(threadName)s] %(levelname)s [%(topic)s] %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
+        jm_logger.addHandler(handler)
+        jm_logger.setLevel(logging.INFO)
+
+        _ANDROID_LOG_HANDLER = handler
+        _ACTIVE_LOG_PATH = log_path
+        if log_path not in _LOG_PATHS:
+            _LOG_PATHS.append(log_path)
+
+
+def _log(topic, message, level=logging.INFO, exc_info=False):
+    try:
+        from jmcomic.jm_config import jm_logger
+
+        jm_logger.log(
+            level,
+            message,
+            extra={"topic": topic},
+            exc_info=exc_info,
+        )
+    except Exception:
+        # Last-resort fallback for failures while the logging system itself is being set up.
+        try:
+            if _ACTIVE_LOG_PATH:
+                with open(_ACTIVE_LOG_PATH, "a", encoding="utf-8") as f:
+                    f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] [{topic}] {message}\n")
+                    f.flush()
+                    os.fsync(f.fileno())
+        except Exception:
+            pass
+
+
+def _mib(value):
+    return round(float(value) / (1024 * 1024), 1)
+
+
+def _resource_snapshot():
+    """Return a compact process/Java/native memory snapshot for the log."""
+    parts = []
+
+    try:
+        wanted = {"VmRSS", "VmHWM", "VmSize", "VmSwap", "Threads"}
+        with open("/proc/self/status", "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                key = line.split(":", 1)[0]
+                if key in wanted:
+                    parts.append(line.strip())
+    except Exception as exc:
+        parts.append(f"proc_status_error={exc!r}")
+
+    try:
+        from java.lang import Runtime
+
+        runtime = Runtime.getRuntime()
+        java_total = int(runtime.totalMemory())
+        java_free = int(runtime.freeMemory())
+        java_max = int(runtime.maxMemory())
+        java_used = java_total - java_free
+        parts.append(
+            f"java_heap={_mib(java_used)}MiB/{_mib(java_max)}MiB "
+            f"(total={_mib(java_total)}MiB free={_mib(java_free)}MiB)"
+        )
+    except Exception as exc:
+        parts.append(f"java_heap_error={exc!r}")
+
+    try:
+        from android.os import Debug
+
+        parts.append(
+            f"native_heap={_mib(int(Debug.getNativeHeapAllocatedSize()))}MiB"
+        )
+    except Exception as exc:
+        parts.append(f"native_heap_error={exc!r}")
+
+    return "; ".join(parts)
 
 
 def _looks_like_webp(data):
@@ -23,25 +157,98 @@ def _decode_webp_with_android(data):
     from java.io import ByteArrayOutputStream
     from PIL import Image
 
-    java_bytes = jarray(jbyte)(data)
-    bitmap = BitmapFactory.decodeByteArray(java_bytes, 0, len(java_bytes))
-    if bitmap is None:
-        raise ValueError("Android BitmapFactory 无法解码该 WebP 图片")
+    raw_size = len(data)
+    t0 = time.perf_counter()
+    bitmap = None
+    output = None
 
-    output = ByteArrayOutputStream()
+    _log(
+        "android.webp.begin",
+        f"WebP fallback start: input={raw_size} bytes; {_resource_snapshot()}",
+    )
+
     try:
+        java_bytes = jarray(jbyte)(data)
+        t_java_bytes = time.perf_counter()
+
+        bitmap = BitmapFactory.decodeByteArray(java_bytes, 0, len(java_bytes))
+        # Release the duplicated Java input byte array as early as possible.
+        del java_bytes
+        t_bitmap = time.perf_counter()
+
+        if bitmap is None:
+            raise ValueError("Android BitmapFactory 无法解码该 WebP 图片")
+
+        width = int(bitmap.getWidth())
+        height = int(bitmap.getHeight())
+        try:
+            bitmap_alloc = int(bitmap.getAllocationByteCount())
+        except Exception:
+            bitmap_alloc = width * height * 4
+
+        _log(
+            "android.webp.bitmap",
+            f"Bitmap decoded: {width}x{height}, approx={_mib(bitmap_alloc)}MiB, "
+            f"python_to_java_ms={(t_java_bytes - t0) * 1000:.1f}, "
+            f"bitmap_decode_ms={(t_bitmap - t_java_bytes) * 1000:.1f}; "
+            f"{_resource_snapshot()}",
+        )
+
+        output = ByteArrayOutputStream()
         ok = bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+        t_png = time.perf_counter()
         if not ok:
             raise ValueError("Android Bitmap.compress(PNG) 失败")
-        png_bytes = bytes(output.toByteArray())
-    finally:
-        bitmap.recycle()
-        output.close()
 
-    image = Image.open(BytesIO(png_bytes))
-    # Pillow is lazy by default. Load now so the in-memory PNG stream can be released.
-    image.load()
-    return image
+        png_size = int(output.size())
+
+        # The bitmap is by far the largest Java/native allocation. Release it before
+        # duplicating PNG bytes into Python/Pillow memory.
+        bitmap.recycle()
+        bitmap = None
+
+        java_png = output.toByteArray()
+        output.close()
+        output = None
+        png_bytes = bytes(java_png)
+        del java_png
+        t_python_png = time.perf_counter()
+
+        image = Image.open(BytesIO(png_bytes))
+        image.load()
+        del png_bytes
+        t_pillow = time.perf_counter()
+
+        _log(
+            "android.webp.end",
+            f"WebP fallback done: {width}x{height}, input={raw_size} bytes, "
+            f"intermediate_png={png_size} bytes, android_png_ms={(t_png - t_bitmap) * 1000:.1f}, "
+            f"java_to_python_ms={(t_python_png - t_png) * 1000:.1f}, "
+            f"pillow_png_decode_ms={(t_pillow - t_python_png) * 1000:.1f}, "
+            f"total_ms={(t_pillow - t0) * 1000:.1f}; {_resource_snapshot()}",
+        )
+        return image
+
+    except Exception:
+        _log(
+            "android.webp.failed",
+            f"WebP fallback failed after {(time.perf_counter() - t0) * 1000:.1f} ms; "
+            f"input={raw_size} bytes; {_resource_snapshot()}",
+            level=logging.ERROR,
+            exc_info=True,
+        )
+        raise
+    finally:
+        if bitmap is not None:
+            try:
+                bitmap.recycle()
+            except Exception:
+                pass
+        if output is not None:
+            try:
+                output.close()
+            except Exception:
+                pass
 
 
 def _install_android_webp_fallback():
@@ -66,12 +273,109 @@ def _install_android_webp_fallback():
 
             raw = bytes(fp)
             if not _looks_like_webp(raw):
+                _log(
+                    "android.image.invalid",
+                    f"Pillow rejected non-WebP bytes: size={len(raw)}, head={raw[:32]!r}",
+                    level=logging.ERROR,
+                )
                 raise
 
             return _decode_webp_with_android(raw)
 
     JmImageTool.open_image = classmethod(patched_open_image)
     JmImageTool._android_webp_fallback_installed = True
+
+
+def _get_android_safe_downloader_class():
+    global _SAFE_DOWNLOADER_CLASS
+    if _SAFE_DOWNLOADER_CLASS is not None:
+        return _SAFE_DOWNLOADER_CLASS
+
+    from jmcomic.jm_downloader import JmDownloader
+
+    class AndroidSafeDownloader(JmDownloader):
+        """JmDownloader with per-photo logs and aggressive resource diagnostics."""
+
+        def __init__(self, option):
+            super().__init__(option)
+            self.android_log_paths = []
+            self._image_started_at = {}
+
+        def before_album(self, album):
+            _log(
+                "android.album.begin",
+                f"Album ready: id={getattr(album, 'id', None)}, title={getattr(album, 'name', None)!r}, "
+                f"photos={len(album)}, page_count={getattr(album, 'page_count', None)}; "
+                f"{_resource_snapshot()}",
+            )
+            return super().before_album(album)
+
+        def before_photo(self, photo):
+            # This is the exact directory in which this photo/chapter's images are saved.
+            image_dir = self.option.decide_image_save_dir(photo, ensure_exists=True)
+            log_path = os.path.join(image_dir, "jmcomic_android.log")
+            _configure_jm_file_logging(log_path)
+            if log_path not in self.android_log_paths:
+                self.android_log_paths.append(log_path)
+
+            _log(
+                "android.photo.begin",
+                f"Photo start: id={getattr(photo, 'id', None)}, name={getattr(photo, 'name', None)!r}, "
+                f"images={len(photo)}, image_dir={image_dir!r}, "
+                f"threading.image={self.option.download.threading.image}, "
+                f"threading.photo={self.option.download.threading.photo}, "
+                f"output_suffix={self.option.download.image.suffix!r}; {_resource_snapshot()}",
+            )
+            return super().before_photo(photo)
+
+        def before_image(self, image, img_save_path):
+            self._image_started_at[id(image)] = time.perf_counter()
+            _log(
+                "android.image.begin",
+                f"Image start: index={getattr(image, 'index', None)}, "
+                f"url={getattr(image, 'img_url', None)!r}, save={img_save_path!r}; "
+                f"{_resource_snapshot()}",
+            )
+            return super().before_image(image, img_save_path)
+
+        def after_image(self, image, img_save_path):
+            result = super().after_image(image, img_save_path)
+            started = self._image_started_at.pop(id(image), None)
+            duration_ms = None if started is None else (time.perf_counter() - started) * 1000
+            try:
+                file_size = os.path.getsize(img_save_path)
+            except Exception:
+                file_size = None
+
+            collected = gc.collect()
+            _log(
+                "android.image.end",
+                f"Image saved: index={getattr(image, 'index', None)}, save={img_save_path!r}, "
+                f"file_size={file_size}, duration_ms={duration_ms}, gc_collected={collected}; "
+                f"{_resource_snapshot()}",
+            )
+            return result
+
+        def after_photo(self, photo):
+            result = super().after_photo(photo)
+            _log(
+                "android.photo.end",
+                f"Photo complete: id={getattr(photo, 'id', None)}, name={getattr(photo, 'name', None)!r}; "
+                f"{_resource_snapshot()}",
+            )
+            return result
+
+        def after_album(self, album):
+            result = super().after_album(album)
+            _log(
+                "android.album.end",
+                f"Album complete: id={getattr(album, 'id', None)}; {_resource_snapshot()}",
+            )
+            return result
+
+    AndroidSafeDownloader.__name__ = "AndroidSafeDownloader"
+    _SAFE_DOWNLOADER_CLASS = AndroidSafeDownloader
+    return AndroidSafeDownloader
 
 
 def diagnostics():
@@ -109,54 +413,118 @@ def diagnostics():
         info["jmcomic"] = getattr(jmcomic, "__version__", "import ok")
         _install_android_webp_fallback()
         info["android_webp_fallback"] = "installed"
+        defaults = jmcomic.JmOption.default()
+        info["jmcomic_default_image_threads"] = defaults.download.threading.image
+        info["android_safe_image_threads"] = 1
+        info["android_safe_photo_threads"] = 1
+        info["android_output_suffix"] = ".png"
     except Exception:
         info["jmcomic_error"] = traceback.format_exc()
 
+    info["resources"] = _resource_snapshot()
     return json.dumps(info, ensure_ascii=False, indent=2)
 
 
 def download_album_by_id(jm_id, output_dir):
+    global _LOG_PATHS
+
+    jm_id = str(jm_id).strip()
+    if not jm_id.isdigit():
+        return json.dumps(
+            {"ok": False, "error": f"无效 JM ID: {jm_id!r}"},
+            ensure_ascii=False,
+            indent=2,
+        )
+
+    os.makedirs(output_dir, exist_ok=True)
+    _LOG_PATHS = []
+
     try:
-        jm_id = str(jm_id).strip()
-        if not jm_id.isdigit():
-            raise ValueError(f"无效 JM ID: {jm_id!r}")
-
-        os.makedirs(output_dir, exist_ok=True)
-
         import jmcomic
 
-        # Chaquopy's Pillow build doesn't include every desktop image codec.
-        # JM currently serves many pages as WebP, so route only genuine WebP
-        # byte streams through Android's native BitmapFactory decoder.
+        # Start a bootstrap log before album metadata is available. Once a chapter
+        # starts, logging switches to jmcomic_android.log inside the actual image dir.
+        bootstrap_log = os.path.join(output_dir, f"JM{jm_id}_android_bootstrap.log")
+        _configure_jm_file_logging(bootstrap_log)
+
+        _log(
+            "android.download.begin",
+            f"Download request: JM{jm_id}, output_dir={output_dir!r}, "
+            f"python={sys.version.split()[0]}, jmcomic={getattr(jmcomic, '__version__', 'unknown')}; "
+            f"{_resource_snapshot()}",
+        )
+
+        # Chaquopy's Pillow build doesn't include WebP. JM serves many pages as
+        # WebP, so route genuine WebP bytes through Android's BitmapFactory.
         _install_android_webp_fallback()
 
-        # 只覆盖下载根目录，其余使用 jmcomic 默认配置。
-        # 当前默认网络层会走 curl_cffi，因此该调用同时验证了 native wheel 是否可用。
+        # IMPORTANT: jmcomic 2.7.5 defaults to 30 image threads. That is suitable
+        # for desktop networking, but disastrous here because each WebP fallback
+        # temporarily allocates a Java Bitmap + PNG buffer + Pillow image. Serialize
+        # both photo and image work until resource measurements prove higher values safe.
+        # Also save as PNG, because this Pillow build cannot encode WebP either.
         option = jmcomic.JmOption.construct({
             "dir_rule": {
                 "base_dir": output_dir,
             },
+            "download": {
+                "threading": {
+                    "image": 1,
+                    "photo": 1,
+                },
+                "image": {
+                    "decode": True,
+                    "suffix": ".png",
+                },
+            },
         })
 
-        result = jmcomic.download_album(jm_id, option)
+        _log(
+            "android.download.config",
+            "Android safe mode enabled: image_threads=1, photo_threads=1, "
+            "decode=True, final_suffix='.png'",
+        )
+
+        downloader_cls = _get_android_safe_downloader_class()
+        result = jmcomic.download_album(jm_id, option, downloader=downloader_cls)
         album = result.detail
+        downloader = result.downloader
+
+        log_paths = list(dict.fromkeys(_LOG_PATHS + getattr(downloader, "android_log_paths", [])))
+        manifest_paths = list(getattr(result.manifest, "image_filepath_list", []) or [])
+
+        _log(
+            "android.download.end",
+            f"Download complete: JM{jm_id}, images={len(manifest_paths)}, "
+            f"duration={getattr(result, 'duration', None)}; {_resource_snapshot()}",
+        )
 
         payload = {
             "ok": True,
             "jm_id": jm_id,
             "title": getattr(album, "title", None),
             "save_path": getattr(album, "save_path", output_dir),
+            "downloaded_images": len(manifest_paths),
             "duration_seconds": getattr(result, "duration", None),
-            "message": "下载完成",
+            "log_files": log_paths,
+            "message": "下载完成（Android 安全模式：单线程解码，最终保存为 PNG）",
         }
         return json.dumps(payload, ensure_ascii=False, indent=2, default=str)
 
     except Exception as exc:
+        _log(
+            "android.download.failed",
+            f"Download failed: JM{jm_id}; {_resource_snapshot()}",
+            level=logging.ERROR,
+            exc_info=True,
+        )
         return json.dumps(
             {
                 "ok": False,
                 "error": repr(exc),
                 "traceback": traceback.format_exc(),
+                "log_files": list(_LOG_PATHS),
+                "active_log": _ACTIVE_LOG_PATH,
             },
             ensure_ascii=False,
             indent=2,

--- a/android_jmcomic_demo/app/src/main/python/jm_bridge.py
+++ b/android_jmcomic_demo/app/src/main/python/jm_bridge.py
@@ -5,12 +5,82 @@ import sys
 import traceback
 
 
+def _looks_like_webp(data):
+    return (
+        isinstance(data, (bytes, bytearray))
+        and len(data) >= 12
+        and data[:4] == b"RIFF"
+        and data[8:12] == b"WEBP"
+    )
+
+
+def _decode_webp_with_android(data):
+    """Decode WebP with Android BitmapFactory, then hand PNG bytes back to Pillow."""
+    from io import BytesIO
+
+    from android.graphics import Bitmap, BitmapFactory
+    from java import jarray, jbyte
+    from java.io import ByteArrayOutputStream
+    from PIL import Image
+
+    java_bytes = jarray(jbyte)(data)
+    bitmap = BitmapFactory.decodeByteArray(java_bytes, 0, len(java_bytes))
+    if bitmap is None:
+        raise ValueError("Android BitmapFactory 无法解码该 WebP 图片")
+
+    output = ByteArrayOutputStream()
+    try:
+        ok = bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+        if not ok:
+            raise ValueError("Android Bitmap.compress(PNG) 失败")
+        png_bytes = bytes(output.toByteArray())
+    finally:
+        bitmap.recycle()
+        output.close()
+
+    image = Image.open(BytesIO(png_bytes))
+    # Pillow is lazy by default. Load now so the in-memory PNG stream can be released.
+    image.load()
+    return image
+
+
+def _install_android_webp_fallback():
+    """Patch jmcomic's image open path only for real WebP byte streams."""
+    from PIL import UnidentifiedImageError
+    from jmcomic.jm_toolkit import JmImageTool
+
+    if getattr(JmImageTool, "_android_webp_fallback_installed", False):
+        return
+
+    original_open_image = JmImageTool.open_image
+
+    def patched_open_image(cls, fp):
+        try:
+            return original_open_image(fp)
+        except UnidentifiedImageError:
+            # jmcomic passes downloaded image bytes here. If this isn't actually
+            # a WebP stream, keep the original exception so CDN/HTTP problems
+            # aren't accidentally hidden by the Android fallback.
+            if isinstance(fp, str):
+                raise
+
+            raw = bytes(fp)
+            if not _looks_like_webp(raw):
+                raise
+
+            return _decode_webp_with_android(raw)
+
+    JmImageTool.open_image = classmethod(patched_open_image)
+    JmImageTool._android_webp_fallback_installed = True
+
+
 def diagnostics():
     info = {
         "python": sys.version,
         "platform": platform.platform(),
         "machine": platform.machine(),
     }
+
     try:
         import curl_cffi
         info["curl_cffi"] = getattr(curl_cffi, "__version__", "unknown")
@@ -18,8 +88,27 @@ def diagnostics():
         info["curl_cffi_error"] = traceback.format_exc()
 
     try:
+        import PIL
+        from PIL import features
+
+        info["pillow"] = getattr(PIL, "__version__", "unknown")
+        info["pillow_webp"] = bool(features.check("webp"))
+    except Exception:
+        info["pillow_error"] = traceback.format_exc()
+
+    try:
+        from android.graphics import BitmapFactory
+
+        info["android_bitmapfactory"] = "available"
+    except Exception:
+        info["android_bitmapfactory_error"] = traceback.format_exc()
+
+    try:
         import jmcomic
+
         info["jmcomic"] = getattr(jmcomic, "__version__", "import ok")
+        _install_android_webp_fallback()
+        info["android_webp_fallback"] = "installed"
     except Exception:
         info["jmcomic_error"] = traceback.format_exc()
 
@@ -35,6 +124,11 @@ def download_album_by_id(jm_id, output_dir):
         os.makedirs(output_dir, exist_ok=True)
 
         import jmcomic
+
+        # Chaquopy's Pillow build doesn't include every desktop image codec.
+        # JM currently serves many pages as WebP, so route only genuine WebP
+        # byte streams through Android's native BitmapFactory decoder.
+        _install_android_webp_fallback()
 
         # 只覆盖下载根目录，其余使用 jmcomic 默认配置。
         # 当前默认网络层会走 curl_cffi，因此该调用同时验证了 native wheel 是否可用。

--- a/android_jmcomic_demo/app/src/main/python/jm_bridge.py
+++ b/android_jmcomic_demo/app/src/main/python/jm_bridge.py
@@ -1,0 +1,69 @@
+import json
+import os
+import platform
+import sys
+import traceback
+
+
+def diagnostics():
+    info = {
+        "python": sys.version,
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+    }
+    try:
+        import curl_cffi
+        info["curl_cffi"] = getattr(curl_cffi, "__version__", "unknown")
+    except Exception:
+        info["curl_cffi_error"] = traceback.format_exc()
+
+    try:
+        import jmcomic
+        info["jmcomic"] = getattr(jmcomic, "__version__", "import ok")
+    except Exception:
+        info["jmcomic_error"] = traceback.format_exc()
+
+    return json.dumps(info, ensure_ascii=False, indent=2)
+
+
+def download_album_by_id(jm_id, output_dir):
+    try:
+        jm_id = str(jm_id).strip()
+        if not jm_id.isdigit():
+            raise ValueError(f"无效 JM ID: {jm_id!r}")
+
+        os.makedirs(output_dir, exist_ok=True)
+
+        import jmcomic
+
+        # 只覆盖下载根目录，其余使用 jmcomic 默认配置。
+        # 当前默认网络层会走 curl_cffi，因此该调用同时验证了 native wheel 是否可用。
+        option = jmcomic.JmOption.construct({
+            "dir_rule": {
+                "base_dir": output_dir,
+            },
+        })
+
+        result = jmcomic.download_album(jm_id, option)
+        album = result.detail
+
+        payload = {
+            "ok": True,
+            "jm_id": jm_id,
+            "title": getattr(album, "title", None),
+            "save_path": getattr(album, "save_path", output_dir),
+            "duration_seconds": getattr(result, "duration", None),
+            "message": "下载完成",
+        }
+        return json.dumps(payload, ensure_ascii=False, indent=2, default=str)
+
+    except Exception as exc:
+        return json.dumps(
+            {
+                "ok": False,
+                "error": repr(exc),
+                "traceback": traceback.format_exc(),
+            },
+            ensure_ascii=False,
+            indent=2,
+        )

--- a/android_jmcomic_demo/app/src/main/res/values/styles.xml
+++ b/android_jmcomic_demo/app/src/main/res/values/styles.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme" parent="android:style/Theme.Material.Light.NoActionBar">
+        <item name="android:fontFamily">sans</item>
+        <item name="android:windowActionModeOverlay">true</item>
+    </style>
+</resources>

--- a/android_jmcomic_demo/build.gradle
+++ b/android_jmcomic_demo/build.gradle
@@ -1,0 +1,4 @@
+plugins {
+    id 'com.android.application' version '8.13.2' apply false
+    id 'com.chaquo.python' version '17.0.0' apply false
+}

--- a/android_jmcomic_demo/gradle.properties
+++ b/android_jmcomic_demo/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx3g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.nonTransitiveRClass=true

--- a/android_jmcomic_demo/settings.gradle
+++ b/android_jmcomic_demo/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "JmcomicAndroidDemo"
+include ':app'


### PR DESCRIPTION
Adds an isolated Android Studio demo under `android_jmcomic_demo/` to validate packaging and running `jmcomic` with `curl_cffi` on Android ARM64 using Chaquopy 17 + CPython 3.13.

The demo:
- keeps the existing backend/frontend untouched;
- pins Android-compatible native Python dependencies;
- provides a minimal Java UI to run diagnostics and download a specified JM album ID;
- saves into the app-specific Pictures/JMComic directory;
- adds CI to assemble a debug APK.

This PR is intentionally a packaging PoC rather than a full Android port of ULTIMATE_WEB.